### PR TITLE
chore(cla): Add CLA and enforce policy for all contributions

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,11 @@
+# Contributor License Agreement (CLA)
+
+By submitting code, documentation, or other content to this repository, you agree to the following terms:
+
+1. You grant the AXCP project and its maintainers a perpetual, irrevocable, worldwide, royalty-free, and non-exclusive license to use, modify, reproduce, display, distribute, sublicense, and create derivative works of your contribution for any purpose, including commercial use.
+
+2. You confirm that you are legally entitled to make the contribution and that it does not violate any intellectual property rights.
+
+3. You agree that no compensation, recognition, or attribution is required in exchange for your contribution.
+
+If you do not agree to these terms, do not submit a pull request or any code to this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to AXCP
+
+Thank you for considering a contribution to AXCP!
+
+## ⚠️ Legal Requirement: Contributor License Agreement (CLA)
+
+Before your contribution can be accepted, you **must read and agree to the CLA** located in [CLA.md](./CLA.md). By submitting a pull request, you confirm your agreement to these terms.
+
+**If you do not agree, do not submit a PR.**
+
+## How to Contribute
+
+1. Fork this repository.
+2. Create a feature branch.
+3. Write your code or documentation.
+4. Ensure all tests pass (`go test ./...`, `pytest`, etc.).
+5. Submit a Pull Request (PR) with a clear description.
+
+All contributions are subject to review and approval by the maintainers. Submissions not aligned with the roadmap or project principles may be declined.
+
+Thanks again!


### PR DESCRIPTION
Introduced a Contributor License Agreement (CLA) and updated the contribution policy accordingly. All future PRs require implicit acceptance of CLA. See CLA.md for full terms