### PR TITLE
feat(v0.3): initialize folder structure and docker scaffolding for edge-mesh beta

### DIFF
--- a/v0.3/compose/docker-compose.yml
+++ b/v0.3/compose/docker-compose.yml
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+version: '3.8'
+
+services:
+  # Edge Gateway Service
+  gateway:
+    build:
+      context: ../../v0.3/edge/gateway
+      dockerfile: Dockerfile
+    ports:
+      - "7143:7143"
+    volumes:
+      - ./certs:/certs:ro
+      - gateway-data:/data
+    environment:
+      - RUST_LOG=info
+    depends_on:
+      - mosquitto
+      - otel-collector
+    networks:
+      - axcp-net
+
+  # MQTT Broker
+  mosquitto:
+    image: eclipse-mosquitto:2.0
+    ports:
+      - "1883:1883"
+    volumes:
+      - ../../v0.3/edge/mqtt/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - mosquitto-data:/mosquitto/data
+    networks:
+      - axcp-net
+
+  # Jaeger for distributed tracing
+  jaeger:
+    image: jaegertracing/all-in-one:1.39
+    ports:
+      - "16686:16686"  # UI
+      - "14250:14250"  # Model proto
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    networks:
+      - axcp-net
+
+  # OpenTelemetry Collector
+  otel-collector:
+    image: otel/opentelemetry-collector:0.68.0
+    command: ["--config=/etc/otel-config.yaml"]
+    volumes:
+      - ../../v0.3/telemetry/otel/otel-config.yaml:/etc/otel-config.yaml
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "55681:55681" # OTLP HTTP
+      - "8889:8889"   # Prometheus metrics
+    depends_on:
+      - jaeger
+    networks:
+      - axcp-net
+
+  # Prometheus for metrics (optional)
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - otel-collector
+    networks:
+      - axcp-net
+
+  # Grafana for visualization (optional)
+  grafana:
+    image: grafana/grafana:9.1.0
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+    networks:
+      - axcp-net
+
+networks:
+  axcp-net:
+    driver: bridge
+
+volumes:
+  gateway-data:
+  mosquitto-data:
+  grafana-storage:

--- a/v0.3/dp/runtime/dp_lib.go
+++ b/v0.3/dp/runtime/dp_lib.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Placeholder – v0.3 structure only
+package dp
+
+import (
+	"math/rand"
+)
+
+// Config holds differential privacy parameters
+type Config struct {
+	Epsilon    float64 `yaml:"epsilon"`
+	Delta      float64 `yaml:"delta"`
+	Mechanism  string  `yaml:"mechanism"`
+	ClipNorm   float64 `yaml:"clip_norm"`
+}
+
+// DPNoiseGenerator interface for different noise mechanisms
+type DPNoiseGenerator interface {
+	AddNoise(value float64) float64
+}
+
+// NewNoiseGenerator creates a new noise generator based on config
+func NewNoiseGenerator(cfg Config) (DPNoiseGenerator, error) {
+	switch cfg.Mechanism {
+	case "laplace":
+		return &LaplaceNoise{Scale: 1.0 / cfg.Epsilon}, nil
+	case "gaussian":
+		return &GaussianNoise{
+			StdDev: calcGaussianNoiseScale(cfg.Epsilon, cfg.Delta, cfg.ClipNorm),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported noise mechanism: %s", cfg.Mechanism)
+	}
+}
+
+// LaplaceNoise implements DP with Laplace mechanism
+type LaplaceNoise struct {
+	Scale float64
+}
+
+func (l *LaplaceNoise) AddNoise(value float64) float64 {
+	// TODO: Implement actual Laplace noise
+	return value + (rand.Float64() - 0.5) * l.Scale
+}
+
+// GaussianNoise implements DP with Gaussian mechanism
+type GaussianNoise struct {
+	StdDev float64
+}
+
+func (g *GaussianNoise) AddNoise(value float64) float64 {
+	// TODO: Implement actual Gaussian noise
+	return value + rand.NormFloat64() * g.StdDev
+}
+
+func calcGaussianNoiseScale(epsilon, delta, clipNorm float64) float64 {
+	// Calculate noise scale for Gaussian mechanism
+	// See: https://arxiv.org/abs/1805.06530
+	return (2 * math.Log(1.25/delta) * clipNorm) / (epsilon * epsilon)
+}

--- a/v0.3/dp/tests/dp_compliance_test.py
+++ b/v0.3/dp/tests/dp_compliance_test.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+
+import numpy as np
+import pytest
+from scipy import stats
+
+class TestDPCompliance:
+    """Differential Privacy compliance tests."""
+    
+    @pytest.fixture
+    def laplace_mechanism(self):
+        """Fixture for Laplace mechanism implementation."""
+        # TODO: Replace with actual implementation
+        def add_noise(values, epsilon):
+            scale = 1.0 / epsilon
+            return values + np.random.laplace(0, scale, len(values))
+        return add_noise
+    
+    def test_laplace_privacy_loss(self, laplace_mechanism):
+        """Test that Laplace mechanism satisfies (ε,0)-DP."""
+        epsilon = 0.5
+        num_samples = 100000
+        
+        # Two adjacent datasets (differing by one element)
+        d1 = np.zeros(num_samples)
+        d2 = np.ones(num_samples)  # Adjacent to d1 (L1 distance = 1)
+        
+        # Add noise
+        noisy_d1 = laplace_mechanism(d1, epsilon)
+        noisy_d2 = laplace_mechanism(d2, epsilon)
+        
+        # Test privacy loss is bounded by e^ε
+        privacy_loss = np.abs(noisy_d1 - noisy_d2)
+        max_observed_loss = np.max(privacy_loss)
+        
+        # Allow some statistical tolerance
+        assert max_observed_loss <= epsilon * 5, \
+            f"Privacy loss {max_observed_loss} exceeds {epsilon*5}*ε"
+    
+    @pytest.mark.skip(reason="Requires actual implementation")
+    def test_gaussian_mechanism(self):
+        """Test that Gaussian mechanism satisfies (ε,δ)-DP."""
+        pass  # TODO: Implement Gaussian mechanism tests
+
+    def test_sensitivity_calculation(self):
+        """Test L1/L2 sensitivity calculations."""
+        # TODO: Add sensitivity calculation tests
+        pass
+
+    @pytest.mark.parametrize("epsilon", [0.1, 0.5, 1.0])
+    def test_epsilon_scaling(self, laplace_mechanism, epsilon):
+        """Test that noise scales correctly with ε."""
+        data = np.ones(10000)
+        noisy = laplace_mechanism(data, epsilon)
+        noise = noisy - data
+        
+        # Higher ε should result in smaller noise
+        noise_std = np.std(noise)
+        expected_scale = 1.0 / epsilon
+        
+        # Allow 10% tolerance
+        assert np.isclose(noise_std, expected_scale, rtol=0.1), \
+            f"Noise scale {noise_std} not close to expected {expected_scale} for ε={epsilon}"

--- a/v0.3/edge/gateway/Dockerfile
+++ b/v0.3/edge/gateway/Dockerfile
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o gateway .
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/gateway .
+EXPOSE 7143
+CMD ["./gateway"]

--- a/v0.3/edge/gateway/config/gateway-config.yaml
+++ b/v0.3/edge/gateway/config/gateway-config.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+
+# Gateway configuration
+gateway:
+  port: 7143
+  tls:
+    enabled: true
+    cert: /certs/cert.pem
+    key: /certs/key.pem
+
+# MQTT broker settings
+mqtt:
+  broker: mqtt://mosquitto:1883
+  client_id: axcp-gateway
+  topics:
+    - axcp/+/up
+    - axcp/+/down
+
+# Persistence
+persistence:
+  enabled: true
+  path: /data/offline
+  max_size_mb: 100
+
+# Telemetry
+telemetry:
+  otlp_endpoint: otel-collector:4317
+  metrics_enabled: true
+  traces_enabled: true

--- a/v0.3/edge/gateway/main.go
+++ b/v0.3/edge/gateway/main.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Placeholder – v0.3 structure only
+package main
+
+func main() {
+	// Edge Gateway implementation will go here
+}

--- a/v0.3/edge/mqtt/mosquitto.conf
+++ b/v0.3/edge/mqtt/mosquitto.conf
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+
+# MQTT Broker Configuration
+listener 1883
+protocol mqtt
+
+# Authentication
+allow_anonymous true
+
+# Logging
+log_dest stdout
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+log_type all
+
+# Message persistence
+persistence true
+persistence_location /mosquitto/data/
+persistence_file mosquitto.db
+
+# Message retention
+max_queued_messages 1000
+message_size_limit 0  # Unlimited
+
+# Security
+# Uncomment to enable TLS
+#listener 8883
+#cafile /mosquitto/certs/ca.crt
+#certfile /mosquitto/certs/server.crt
+#keyfile /mosquitto/certs/server.key
+#require_certificate false

--- a/v0.3/rust/axcp-rs/Cargo.toml
+++ b/v0.3/rust/axcp-rs/Cargo.toml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+[package]
+name = "axcp-rs"
+version = "0.3.0"
+authors = ["AXCP Team"]
+edition = "2021"
+description = "Rust implementation of AXCP protocol"
+license = "Apache-2.0"
+repository = "https://github.com/tradephantom/axcp-spec"
+
+[dependencies]
+# Core dependencies
+tokio = { version = "1.0", features = ["full"] }
+quinn = "0.10.0"
+prost = "0.11.0"
+tonic = { version = "0.8.0", features = ["tls"] }
+thiserror = "1.0.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Async runtime
+tokio-util = { version = "0.7.0", features = ["codec"] }
+
+# Logging
+tracing = "0.1.0"
+tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
+
+# Configuration
+config = "0.13.0"
+
+[dev-dependencies]
+# Test dependencies
+proptest = "1.0.0"
+tokio-test = "0.4.0"
+
+[build-dependencies]
+prost-build = "0.11.0"

--- a/v0.3/rust/axcp-rs/src/lib.rs
+++ b/v0.3/rust/axcp-rs/src/lib.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Placeholder – v0.3 structure only
+
+//! # AXCP Rust Implementation
+//! 
+//! A high-performance, zero-copy implementation of the AXCP protocol in Rust.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+pub mod client;
+pub mod error;
+pub mod quic;
+pub mod types;
+
+/// Re-exports for common usage
+pub use client::AxcpClient;
+pub use error::{AxcpError, Result};
+
+/// Current protocol version
+pub const PROTOCOL_VERSION: &str = "0.3.0";
+
+/// Core AXCP client implementation
+#[derive(Debug)]
+pub struct AxcpClient {
+    // TODO: Implement client state
+}
+
+impl AxcpClient {
+    /// Creates a new AXCP client
+    pub fn new() -> Self {
+        Self {
+            // Initialize client state
+        }
+    }
+
+    /// Connects to an AXCP server
+    pub async fn connect(&mut self, _endpoint: &str) -> Result<()> {
+        // TODO: Implement connection logic
+        Ok(())
+    }
+}
+
+/// Error type for AXCP operations
+#[derive(Debug, thiserror::Error)]
+pub enum AxcpError {
+    /// Connection error
+    #[error("connection error: {0}")]
+    Connection(#[from] std::io::Error),
+    
+    /// Protocol error
+    #[error("protocol error: {0}")]
+    Protocol(String),
+    
+    /// Invalid configuration
+    #[error("invalid configuration: {0}")]
+    Config(String),
+}
+
+/// Result type for AXCP operations
+pub type Result<T> = std::result::Result<T, AxcpError>;

--- a/v0.3/telemetry/otel/otel-config.yaml
+++ b/v0.3/telemetry/otel/otel-config.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Placeholder – v0.3 structure only
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:55681
+
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 10s
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 100
+    spike_limit_mib: 25
+
+exporters:
+  logging:
+    loglevel: info
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    const_labels:
+      service: axcp
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [logging]


### PR DESCRIPTION
This PR sets up the foundational structure for the AXCP v0.3 milestone (“Edge-Mesh & Beta-Privacy”).

✅ Created base folder tree for:
- Edge Gateway (Go) – `v0.3/edge/gateway/`
- DP runtime & compliance – `v0.3/dp/`
- Rust SDK scaffolding – `v0.3/rust/`
- OpenTelemetry config – `v0.3/telemetry/`
- Docker stack – `v0.3/compose/docker-compose.yml`

📦 Includes placeholder stubs for:
- `main.go`, `Dockerfile`, config stubs
- `dp_lib.go`, test scaffold
- `Cargo.toml`, `lib.rs`
- `otel-config.yaml`

📌 SPDX headers and Apache-2.0 license included in all created files.
