### PR TITLE
fix(rust): ensure publishable crate config for axcp-rs (Issue #25a)

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "axcp-rs"
 version = "0.1.0-alpha.1"
+publish = true
 edition = "2021"
 description = "Rust client SDK for AXCP protocol"
 license = "Apache-2.0"


### PR DESCRIPTION
Adds `publish = true` to the Cargo.toml of the Rust SDK crate (`axcp-rs`)  
This is the final requirement to allow CI to publish the crate on crates.io after the tag push.

✅ Verificato:
- `publish = true` attivo nel blocco [package]
- Tutti i metadati obbligatori presenti (name, version, license, readme, repository, etc.)
- Nessun blocco alla pubblicazione rilevato (es. exclude, publish = false)

🔧 Completato:
- Commit e push dal branch `fix/cargo-udeps-finalize-v2`
- Pronto per essere mergiato su `main` e per il push del tag `axcp-rs-0.1.0-alpha3`

Closes #25a
