### PR TITLE
fix(sdk): bump version to alpha.4 and correct protocol name (Issue #25a)

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axcp-rs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.4"
 publish = true
 edition = "2021"
 description = "Rust client SDK for AXCP protocol"


### PR DESCRIPTION
This PR updates the axcp-rs crate metadata and documentation for crates.io:

Bumps the crate version from 0.1.0-alpha.1 to 0.1.0-alpha.4 to avoid republishing conflict.

Ensures proper declaration of the protocol name as Adaptive eXchange Context Protocol (AXCP) instead of the incorrect "Advanced eXchange Control Protocol".

Confirms license declaration via license-file remains valid and compliant with BSL 1.1.

Dry-run check has been performed to ensure publish readiness.

Once merged, a new tag axcp-rs-0.1.0-alpha.4 should be pushed to trigger CI and publish to crates.io.