### PR TITLE
chore(version): bump to 0.1.0-alpha.5 for crates.io publish

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "axcp-rs"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 publish = true
 edition = "2021"
 description = "Rust client SDK for AXCP protocol"
-license-file = "../../LICENSE"
+license-file = "LICENSE.BSL"
 authors = ["AXCP Team"]
 repository = "https://github.com/tradephantom/axcp-spec"
 documentation = "https://docs.rs/axcp-rs"


### PR DESCRIPTION
This PR updates the `Cargo.toml` for the Rust SDK (`axcp-rs`) to:

- Bump version to `0.1.0-alpha.5` to allow publishing to crates.io
- Fix license file reference to ensure proper display on the crates.io page

This addresses the failed publish attempt caused by the already existing version `alpha.4`.

Closes #28
