### PR TITLE
fix(publish): regenerate Cargo.lock after retry-buffer merge

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -77,8 +77,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axcp-rs"
-version = "0.1.0-alpha.5"
+name = "axcp-sdk"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bytes",
  "config",


### PR DESCRIPTION
This PR updates the Cargo.lock file after merging the retry-buffer (#63). It ensures a clean publish context for crates.io release v0.1.0-alpha.6.

Closes #62 