### PR TITLE
fix(readme): correct license notice for AXCP Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # axcp-spec
 
 > **Dual Licence Notice** – this repo ships  
-> • **AXCP Core** (Apache 2.0) – fully open-source  
+> • **AXCP Core** (BSL 1.1 → Apache 2.0 in 2029) – source-available  
 > • **AXCP Enterprise** (Commercial) – under `enterprise/`  
 > See `ENTERPRISE_NOTICE.md` for details.
 


### PR DESCRIPTION
This PR updates the **Dual Licence Notice** section in the `README.md` to reflect the correct license used by AXCP Core.

**What changed:**
- Corrected: “AXCP Core (Apache 2.0)” → “AXCP Core (BSL 1.1 / Apache 2.0 fallback)”
- Clarifies the repository’s dual-track licensing structure for Core and Enterprise code.

🟢 This change affects only documentation. No code or dependency modifications involved.

Follow-up to PR #68.
