### PR TITLE
fix/license-readme-alpha20

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axcp-sdk"
-version = "0.1.0-alpha.19"
+version = "0.1.0-alpha.20"
 dependencies = [
  "bytes",
  "config",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 [package]
 name = "axcp-sdk"
-version = "0.1.0-alpha.19"
+version = "0.1.0-alpha.20"
 publish = true
 edition = "2021"
 description = "Rust client SDK for AXCP protocol"


### PR DESCRIPTION
Bump SDK version to `0.1.0-alpha.20` and regenerate `Cargo.lock` to allow successful publish to crates.io.

Previous version `alpha19` was already published, and the re-run of the CI failed due to duplicate version attempt. No other changes included in this PR.

This commit includes:
- `Cargo.toml` updated to alpha.20
- Fresh `Cargo.lock` regenerated via `cargo build`

This ensures the CI pipeline runs green again and unblocks Issue #39.
