### PR TITLE
chore(sdk): bump version to 0.3.1-beta and regenerate lockfile

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axcp-sdk"
-version = "0.3.0-beta"
+version = "0.3.1-beta"
 dependencies = [
  "bytes",
  "config",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 [package]
 name = "axcp-sdk"
-version = "0.3.0-beta"
+version = "0.3.1-beta"
 publish = true
 edition = "2021"
 description = "Rust client SDK for AXCP protocol"


### PR DESCRIPTION
Updated sdk/rust/Cargo.toml and regenerated Cargo.lock for 0.3.1-beta.