### PR TITLE
chore(sdk): bump version to 0.3.2-beta and regenerate lockfile

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axcp-sdk"
-version = "0.3.1-beta"
+version = "0.3.2-beta"
 dependencies = [
  "bytes",
  "config",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 [package]
 name = "axcp-sdk"
-version = "0.3.1-beta"
+version = "0.3.2-beta"
 publish = true
 edition = "2021"
 description = "Rust client SDK for AXCP protocol"


### PR DESCRIPTION
This PR bumps the SDK version to 0.3.2-beta and regenerates the Cargo.lock file to reflect the updated dependency state.
It also finalizes the migration of all Enterprise-specific code (including metrics modules and secure telemetry) from the axcp-spec repo to the new private Enterprise repo, ensuring the public repository only retains placeholders as required.

Changes

Updated Cargo.toml version to 0.3.2-beta

Regenerated Cargo.lock

Confirmed removal of remaining Enterprise source code from public repo

Ensured public repo now aligns with the open-source policy and license separation

Notes
This marks the final cleanup step for Issue #34 and prepares the repo for the v0.3-edge-beta release tag.