### PR TITLE
docs: add demo video thumbnail to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/tradephantomllc/axcp-spec/sdk/go.svg)](https://pkg.go.dev/github.com/tradephantomllc/axcp-spec/sdk/go)
 ![License](https://img.shields.io/badge/license-Apache_2.0-green)
 
+## Demo
+
+[![AXCP Demo](https://img.youtube.com/vi/8rw4d-xnWks/maxresdefault.jpg)](https://youtu.be/8rw4d-xnWks)
+
 > **Quick Start**: see [`docs/getting-started.md`](docs/getting-started.md)
 
 AXCP – Adaptive eXchange Context Protocol. An open specification for ultra-efficient AI agent orchestration.


### PR DESCRIPTION
## Summary
- Add clickable YouTube thumbnail linking to the AXCP demo video
- Makes the demo more visible and accessible directly from the repository

## Test plan
- [x] Verify thumbnail renders correctly on GitHub
- [x] Verify link opens correct YouTube video

🤖 Generated with [Claude Code](https://claude.ai/code)