### PR TITLE
fix: pin protobuf toolchain in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ on:
 env:
   GO_VERSION:  '1.23.4'
   PYTHON_VERSION: '3.11'
-  PROTOC_VERSION: '25.1'
+  PROTOC_VERSION: '33.2'
+  PROTOC_GEN_GO_VERSION: 'v1.36.11'
 
 # ------------------------------------------------------------
 # 1️⃣  GO – unit tests  (verde)
@@ -45,9 +46,16 @@ jobs:
 
       - name: Install protoc + plugin
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y protobuf-compiler
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          set -euo pipefail
+          curl -fsSL \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+            -o "${RUNNER_TEMP}/protoc.zip"
+          unzip -q "${RUNNER_TEMP}/protoc.zip" -d "${RUNNER_TEMP}/protoc"
+          echo "${RUNNER_TEMP}/protoc/bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/protoc/bin/protoc" --version
+          go install "google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+          "$(go env GOPATH)/bin/protoc-gen-go" --version
 
       - name: Generate Go stubs
         working-directory: sdk/go


### PR DESCRIPTION
## Summary
- pin CI protoc to 33.2 to match committed generated Go stubs
- pin protoc-gen-go to v1.36.11 and expose GOPATH/bin explicitly
- replace Ubuntu apt protobuf-compiler to avoid runner package drift

## Verification
- PATH="/Users/tradephantom/go/bin:/Users/tradephantom/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/tradephantom/.codex/tmp/arg0/codex-arg03BKCHo:/Users/tradephantom/.local/bin:/Users/tradephantom/.antigravity/antigravity/bin:/Users/tradephantom/.codeium/windsurf/bin:/Users/tradephantom/.cargo/bin:/Users/tradephantom/.lmstudio/bin:/Applications/Codex.app/Contents/Resources" protoc -I ../../proto --go_out=internal/pb --go_opt=paths=source_relative ../../proto/axcp.proto
- git diff --exit-code proto/axcp.proto sdk/go/internal/pb/axcp.pb.go
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- git diff --check