### PR TITLE
[codex] Add Python QUIC transport

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,7 @@ The Python SDK covers the Secure Baseline application-layer contract:
 - AXCP auth transcript signing and verification
 - timestamp and replay validation
 - profile negotiation primitives
+- async QUIC stream transport
 
 Install it locally from the repository:
 
@@ -67,8 +68,8 @@ alice.sign_message(env, recipient_did=bob.identity.did)
 bob.verify(env)
 ```
 
-Python QUIC transport is intentionally separate from this core SDK and will be
-added after the signing/protobuf/replay contract remains stable.
+Python QUIC transport is available through `axcp.transport` and preserves the
+Go SDK framing contract for both raw messages and protobuf envelopes.
 
 ## Running the Authenticated Chat Example
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -11,9 +11,8 @@ This package covers the application-layer security surface:
 - timestamp validation
 - sequence replay protection
 - Secure Baseline profile negotiation
-
-QUIC transport is intentionally out of scope for Phase 1 and will be added as
-a separate transport package once the core envelope contract is stable.
+- async QUIC stream transport with AXCP envelope framing
+- QUIC DATAGRAM helpers for telemetry-sized payloads
 
 ## Install locally
 
@@ -38,6 +37,33 @@ env.context_patch.CopyFrom(
 alice.sign_message(env, recipient_did=bob.identity.did)
 bob.verify(env)
 ```
+
+## QUIC transport
+
+The transport module uses `aioquic` and preserves the Go SDK framing contract:
+
+- `send_message` / `receive_message`: 4-byte big-endian length prefix
+- `send_envelope` / `receive_envelope`: 4-byte little-endian length prefix
+- `send_datagram` / `receive_datagram`: QUIC DATAGRAM payloads without stream framing
+
+Minimal client usage:
+
+```python
+from axcp import QuicClient, QuicClientConfig
+
+client = await QuicClient.connect(
+    QuicClientConfig(host="127.0.0.1", port=61300, server_name="localhost")
+)
+try:
+    await client.send_envelope(env)
+    reply = await client.receive_envelope()
+finally:
+    await client.close()
+```
+
+Certificate verification is enabled by default. Use `ca_file` for private CA
+deployments. `insecure_skip_verify=True` is available only for explicit local
+development and tests.
 
 ## Verification
 

--- a/sdk/python/examples/secure_quic_echo.py
+++ b/sdk/python/examples/secure_quic_echo.py
@@ -1,0 +1,103 @@
+import argparse
+import asyncio
+
+from axcp import Agent, Identity, QuicClient, QuicClientConfig, QuicServer, QuicServerConfig
+from axcp.pb import axcp_pb2
+from axcp.transport import QuicConnection
+
+
+def build_envelope(agent: Agent, recipient_did: str, trace_id: str) -> axcp_pb2.AxcpEnvelope:
+    env = agent.new_envelope(trace_id=trace_id)
+    env.context_patch.CopyFrom(
+        axcp_pb2.ContextPatch(
+            context_id="demo",
+            base_version=1,
+            ops=[
+                axcp_pb2.DeltaOp(
+                    op=axcp_pb2.DeltaOp.ADD,
+                    path="/message",
+                    data=b"hello axcp over quic",
+                    ts=1,
+                )
+            ],
+        )
+    )
+    agent.sign_message(env, recipient_did=recipient_did)
+    return env
+
+
+async def run_server(args: argparse.Namespace) -> None:
+    server_agent = Agent(Identity.generate())
+
+    async def handler(conn: QuicConnection) -> None:
+        incoming = await conn.receive_envelope()
+        server_agent.verify(incoming)
+        reply = build_envelope(server_agent, incoming.sender_did, incoming.trace_id)
+        await conn.send_envelope(reply)
+
+    server = await QuicServer.listen(
+        QuicServerConfig(
+            host=args.host,
+            port=args.port,
+            cert_file=args.cert,
+            key_file=args.key,
+        ),
+        handler,
+    )
+    host, port = server.address
+    print(f"AXCP Python QUIC echo server listening on {host}:{port}")
+    print(f"Server DID: {server_agent.identity.did}")
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await server.close()
+
+
+async def run_client(args: argparse.Namespace) -> None:
+    client_agent = Agent(Identity.generate())
+    server_did = args.server_did or ""
+    client = await QuicClient.connect(
+        QuicClientConfig(
+            host=args.host,
+            port=args.port,
+            server_name=args.server_name,
+            ca_file=args.ca_file,
+            insecure_skip_verify=args.insecure_skip_verify,
+        )
+    )
+    try:
+        await client.send_envelope(build_envelope(client_agent, server_did, "python-quic-echo"))
+        reply = await client.receive_envelope()
+        client_agent.verify(reply)
+        print(f"verified reply from {reply.sender_did}: {reply.context_patch.context_id}")
+    finally:
+        await client.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AXCP Python secure QUIC echo example")
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    server = sub.add_parser("server")
+    server.add_argument("--host", default="127.0.0.1")
+    server.add_argument("--port", type=int, default=61300)
+    server.add_argument("--cert", required=True)
+    server.add_argument("--key", required=True)
+
+    client = sub.add_parser("client")
+    client.add_argument("--host", default="127.0.0.1")
+    client.add_argument("--port", type=int, default=61300)
+    client.add_argument("--server-name", default="localhost")
+    client.add_argument("--server-did")
+    client.add_argument("--ca-file")
+    client.add_argument("--insecure-skip-verify", action="store_true")
+
+    args = parser.parse_args()
+    if args.mode == "server":
+        asyncio.run(run_server(args))
+    else:
+        asyncio.run(run_client(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
   { name = "TradePhantom LLC", email = "enterprise@getaxcp.com" }
 ]
 dependencies = [
+  "aioquic>=1.3.0",
   "protobuf>=6.31.1",
   "PyNaCl>=1.5.0"
 ]

--- a/sdk/python/src/axcp/__init__.py
+++ b/sdk/python/src/axcp/__init__.py
@@ -20,6 +20,7 @@ from axcp.profile import (
 )
 from axcp.replay import ReplayProtector
 from axcp.timestamp import TimestampValidator, now_ms
+from axcp.transport import QuicClient, QuicClientConfig, QuicServer, QuicServerConfig
 
 __all__ = [
     "Agent",
@@ -31,6 +32,10 @@ __all__ = [
     "InMemoryDIDResolver",
     "Profile",
     "PublicKeyRecord",
+    "QuicClient",
+    "QuicClientConfig",
+    "QuicServer",
+    "QuicServerConfig",
     "ReplayProtector",
     "ServerHello",
     "TimestampValidator",

--- a/sdk/python/src/axcp/transport/__init__.py
+++ b/sdk/python/src/axcp/transport/__init__.py
@@ -1,0 +1,31 @@
+"""AXCP QUIC transport primitives."""
+
+from axcp.transport.quic import (
+    DEFAULT_ALPN,
+    MAX_DATAGRAM_SIZE,
+    MAX_FRAME_SIZE,
+    QuicClient,
+    QuicClientConfig,
+    QuicConnection,
+    QuicServer,
+    QuicServerConfig,
+    TransportClosedError,
+    TransportConfigError,
+    TransportFrameError,
+    TransportTimeoutError,
+)
+
+__all__ = [
+    "DEFAULT_ALPN",
+    "MAX_DATAGRAM_SIZE",
+    "MAX_FRAME_SIZE",
+    "QuicClient",
+    "QuicClientConfig",
+    "QuicConnection",
+    "QuicServer",
+    "QuicServerConfig",
+    "TransportClosedError",
+    "TransportConfigError",
+    "TransportFrameError",
+    "TransportTimeoutError",
+]

--- a/sdk/python/src/axcp/transport/quic.py
+++ b/sdk/python/src/axcp/transport/quic.py
@@ -1,0 +1,411 @@
+"""Async QUIC transport for AXCP envelopes."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import ssl
+import struct
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from aioquic.asyncio import QuicConnectionProtocol
+from aioquic.asyncio import connect as aioquic_connect
+from aioquic.asyncio import serve as aioquic_serve
+from aioquic.quic.configuration import QuicConfiguration
+from aioquic.quic.events import DatagramFrameReceived, QuicEvent
+
+from axcp.envelope import decode_envelope, encode_envelope
+from axcp.pb import axcp_pb2
+
+DEFAULT_ALPN = "axcp/1"
+MAX_FRAME_SIZE = 10 * 1024 * 1024
+MAX_DATAGRAM_SIZE = 1200
+
+FrameEndian = Literal["big", "little"]
+StreamHandler = Callable[["QuicConnection"], Awaitable[None] | None]
+DatagramHandler = Callable[["_AXCPQuicProtocol", bytes], Awaitable[None] | None]
+
+
+class TransportError(Exception):
+    """Base class for QUIC transport errors."""
+
+
+class TransportConfigError(TransportError):
+    """Transport configuration is invalid."""
+
+
+class TransportClosedError(TransportError):
+    """Connection or stream was closed before the operation completed."""
+
+
+class TransportFrameError(TransportError):
+    """A length-prefixed QUIC frame is malformed."""
+
+
+class TransportTimeoutError(TransportError):
+    """A transport operation timed out."""
+
+
+class _AXCPQuicProtocol(QuicConnectionProtocol):
+    def __init__(
+        self,
+        *args,
+        datagram_handler: DatagramHandler | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._datagram_handler = datagram_handler
+        self._datagrams: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def quic_event_received(self, event: QuicEvent) -> None:
+        super().quic_event_received(event)
+        if isinstance(event, DatagramFrameReceived):
+            self._datagrams.put_nowait(event.data)
+            if self._datagram_handler is not None:
+                result = self._datagram_handler(self, event.data)
+                if inspect.isawaitable(result):
+                    asyncio.create_task(result)
+
+    def send_datagram(self, data: bytes) -> None:
+        self._quic.send_datagram_frame(data)
+        self.transmit()
+
+    async def receive_datagram(self, timeout: float | None = None) -> bytes:
+        try:
+            if timeout is None:
+                return await self._datagrams.get()
+            return await asyncio.wait_for(self._datagrams.get(), timeout=timeout)
+        except TimeoutError as exc:
+            raise TransportTimeoutError("timed out waiting for QUIC datagram") from exc
+
+
+@dataclass(frozen=True)
+class QuicClientConfig:
+    host: str
+    port: int
+    server_name: str | None = None
+    ca_file: str | None = None
+    insecure_skip_verify: bool = False
+    alpn_protocols: tuple[str, ...] = (DEFAULT_ALPN,)
+    idle_timeout: float = 60.0
+    max_frame_size: int = MAX_FRAME_SIZE
+    max_datagram_size: int = MAX_DATAGRAM_SIZE
+
+    def validate(self) -> None:
+        if not self.host:
+            raise TransportConfigError("host is required")
+        if not (0 < self.port <= 65535):
+            raise TransportConfigError("port must be between 1 and 65535")
+        if not self.alpn_protocols:
+            raise TransportConfigError("at least one ALPN protocol is required")
+        if self.idle_timeout <= 0:
+            raise TransportConfigError("idle_timeout must be positive")
+        if self.max_frame_size <= 0:
+            raise TransportConfigError("max_frame_size must be positive")
+        if self.max_datagram_size <= 0:
+            raise TransportConfigError("max_datagram_size must be positive")
+
+
+@dataclass(frozen=True)
+class QuicServerConfig:
+    host: str
+    port: int
+    cert_file: str
+    key_file: str
+    alpn_protocols: tuple[str, ...] = (DEFAULT_ALPN,)
+    idle_timeout: float = 60.0
+    max_frame_size: int = MAX_FRAME_SIZE
+    max_datagram_size: int = MAX_DATAGRAM_SIZE
+
+    def validate(self) -> None:
+        if not self.host:
+            raise TransportConfigError("host is required")
+        if not (0 <= self.port <= 65535):
+            raise TransportConfigError("port must be between 0 and 65535")
+        if not self.cert_file:
+            raise TransportConfigError("cert_file is required")
+        if not self.key_file:
+            raise TransportConfigError("key_file is required")
+        if not self.alpn_protocols:
+            raise TransportConfigError("at least one ALPN protocol is required")
+        if self.idle_timeout <= 0:
+            raise TransportConfigError("idle_timeout must be positive")
+        if self.max_frame_size <= 0:
+            raise TransportConfigError("max_frame_size must be positive")
+        if self.max_datagram_size <= 0:
+            raise TransportConfigError("max_datagram_size must be positive")
+
+
+def _client_configuration(config: QuicClientConfig) -> QuicConfiguration:
+    quic_config = QuicConfiguration(
+        is_client=True,
+        alpn_protocols=list(config.alpn_protocols),
+        idle_timeout=config.idle_timeout,
+        max_datagram_frame_size=config.max_datagram_size,
+    )
+    quic_config.server_name = config.server_name or config.host
+    if config.insecure_skip_verify:
+        quic_config.verify_mode = ssl.CERT_NONE
+    elif config.ca_file is not None:
+        quic_config.load_verify_locations(cafile=config.ca_file)
+    return quic_config
+
+
+def _server_configuration(config: QuicServerConfig) -> QuicConfiguration:
+    quic_config = QuicConfiguration(
+        is_client=False,
+        alpn_protocols=list(config.alpn_protocols),
+        idle_timeout=config.idle_timeout,
+        max_datagram_frame_size=config.max_datagram_size,
+    )
+    quic_config.load_cert_chain(config.cert_file, config.key_file)
+    return quic_config
+
+
+async def _read_frame(
+    reader: asyncio.StreamReader,
+    *,
+    endian: FrameEndian,
+    max_frame_size: int,
+    timeout: float | None = None,
+) -> bytes:
+    try:
+        if timeout is None:
+            header = await reader.readexactly(4)
+        else:
+            header = await asyncio.wait_for(reader.readexactly(4), timeout=timeout)
+    except asyncio.IncompleteReadError as exc:
+        raise TransportClosedError("stream closed while reading frame header") from exc
+    except TimeoutError as exc:
+        raise TransportTimeoutError("timed out reading frame header") from exc
+
+    frame_len = struct.unpack(">I" if endian == "big" else "<I", header)[0]
+    if frame_len > max_frame_size:
+        raise TransportFrameError(f"frame length {frame_len} exceeds max_frame_size {max_frame_size}")
+
+    try:
+        if timeout is None:
+            return await reader.readexactly(frame_len)
+        return await asyncio.wait_for(reader.readexactly(frame_len), timeout=timeout)
+    except asyncio.IncompleteReadError as exc:
+        raise TransportClosedError("stream closed while reading frame payload") from exc
+    except TimeoutError as exc:
+        raise TransportTimeoutError("timed out reading frame payload") from exc
+
+
+async def _write_frame(
+    writer: asyncio.StreamWriter,
+    data: bytes,
+    *,
+    endian: FrameEndian,
+    max_frame_size: int,
+) -> None:
+    if len(data) > max_frame_size:
+        raise TransportFrameError(f"frame length {len(data)} exceeds max_frame_size {max_frame_size}")
+    writer.write(struct.pack(">I" if endian == "big" else "<I", len(data)) + data)
+    await asyncio.sleep(0)
+
+
+class QuicConnection:
+    """AXCP stream connection over QUIC."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        max_frame_size: int = MAX_FRAME_SIZE,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._max_frame_size = max_frame_size
+        self._send_lock = asyncio.Lock()
+        self._recv_lock = asyncio.Lock()
+        self._closed = False
+
+    async def send_message(self, data: bytes) -> None:
+        """Send raw bytes using Go `SendMessage` big-endian framing."""
+
+        async with self._send_lock:
+            self._ensure_open()
+            await _write_frame(self._writer, data, endian="big", max_frame_size=self._max_frame_size)
+
+    async def receive_message(self, timeout: float | None = None) -> bytes:
+        """Receive raw bytes using Go `ReceiveMessage` big-endian framing."""
+
+        async with self._recv_lock:
+            self._ensure_open()
+            return await _read_frame(
+                self._reader,
+                endian="big",
+                max_frame_size=self._max_frame_size,
+                timeout=timeout,
+            )
+
+    async def send_envelope(self, envelope: axcp_pb2.AxcpEnvelope) -> None:
+        """Send an envelope using Go `SendEnvelope` little-endian framing."""
+
+        async with self._send_lock:
+            self._ensure_open()
+            await _write_frame(
+                self._writer,
+                encode_envelope(envelope),
+                endian="little",
+                max_frame_size=self._max_frame_size,
+            )
+
+    async def receive_envelope(self, timeout: float | None = None) -> axcp_pb2.AxcpEnvelope:
+        """Receive an envelope using Go `RecvEnvelope` little-endian framing."""
+
+        async with self._recv_lock:
+            self._ensure_open()
+            data = await _read_frame(
+                self._reader,
+                endian="little",
+                max_frame_size=self._max_frame_size,
+                timeout=timeout,
+            )
+            return decode_envelope(data)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._writer.close()
+        await asyncio.sleep(0)
+
+    def _ensure_open(self) -> None:
+        if self._closed or self._writer.is_closing():
+            raise TransportClosedError("QUIC stream is closed")
+
+
+class QuicClient(QuicConnection):
+    """AXCP QUIC client with one bidirectional control stream."""
+
+    def __init__(
+        self,
+        config: QuicClientConfig,
+        context_manager,
+        protocol: _AXCPQuicProtocol,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        super().__init__(reader, writer, max_frame_size=config.max_frame_size)
+        self._config = config
+        self._context_manager = context_manager
+        self._protocol = protocol
+
+    @classmethod
+    async def connect(cls, config: QuicClientConfig) -> "QuicClient":
+        config.validate()
+        context_manager = aioquic_connect(
+            config.host,
+            config.port,
+            configuration=_client_configuration(config),
+            create_protocol=_AXCPQuicProtocol,
+            wait_connected=True,
+        )
+        protocol = await context_manager.__aenter__()
+        reader, writer = await protocol.create_stream()
+        return cls(config, context_manager, protocol, reader, writer)
+
+    async def __aenter__(self) -> "QuicClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def send_datagram(self, data: bytes) -> None:
+        if len(data) > self._config.max_datagram_size:
+            raise TransportFrameError(
+                f"datagram length {len(data)} exceeds max_datagram_size {self._config.max_datagram_size}"
+            )
+        self._protocol.send_datagram(data)
+        await asyncio.sleep(0)
+
+    async def receive_datagram(self, timeout: float | None = None) -> bytes:
+        return await self._protocol.receive_datagram(timeout=timeout)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        await super().close()
+        await self._context_manager.__aexit__(None, None, None)
+
+
+class QuicServer:
+    """AXCP QUIC server."""
+
+    def __init__(
+        self,
+        config: QuicServerConfig,
+        server,
+        tasks: set[asyncio.Task],
+    ) -> None:
+        self._config = config
+        self._server = server
+        self._tasks = tasks
+        self._closed = False
+
+    @classmethod
+    async def listen(
+        cls,
+        config: QuicServerConfig,
+        handler: StreamHandler,
+        *,
+        datagram_handler: DatagramHandler | None = None,
+    ) -> "QuicServer":
+        config.validate()
+        tasks: set[asyncio.Task] = set()
+
+        def stream_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            connection = QuicConnection(reader, writer, max_frame_size=config.max_frame_size)
+            task = asyncio.create_task(_run_stream_handler(handler, connection))
+            tasks.add(task)
+            task.add_done_callback(tasks.discard)
+
+        def create_protocol(*args, **kwargs):
+            return _AXCPQuicProtocol(*args, datagram_handler=datagram_handler, **kwargs)
+
+        server = await aioquic_serve(
+            config.host,
+            config.port,
+            configuration=_server_configuration(config),
+            create_protocol=create_protocol,
+            stream_handler=stream_handler,
+        )
+        return cls(config, server, tasks)
+
+    @property
+    def address(self) -> tuple[str, int]:
+        sockname = self._server._transport.get_extra_info("sockname")
+        return sockname[0], sockname[1]
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._server.close()
+        if self._tasks:
+            done, pending = await asyncio.wait(self._tasks, timeout=2)
+            for task in pending:
+                task.cancel()
+            for task in done:
+                task.result()
+
+    async def __aenter__(self) -> "QuicServer":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+
+async def _run_stream_handler(handler: StreamHandler, connection: QuicConnection) -> None:
+    try:
+        result = handler(connection)
+        if inspect.isawaitable(result):
+            await result
+    finally:
+        await connection.close()

--- a/sdk/python/tests/test_quic_transport.py
+++ b/sdk/python/tests/test_quic_transport.py
@@ -1,0 +1,209 @@
+import asyncio
+import ipaddress
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from axcp import Agent, Identity, QuicClient, QuicClientConfig, QuicServer, QuicServerConfig
+from axcp.pb import axcp_pb2
+from axcp.transport import QuicConnection, TransportFrameError, TransportTimeoutError
+
+
+def _write_self_signed_cert(tmp_path: Path) -> tuple[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "AXCP Tests"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "localhost"),
+        ]
+    )
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    cert_file = tmp_path / "cert.pem"
+    key_file = tmp_path / "key.pem"
+    cert_file.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_file.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    return str(cert_file), str(key_file)
+
+
+def _context_envelope(trace_id: str = "quic-trace"):
+    env = axcp_pb2.AxcpEnvelope(version=1, trace_id=trace_id, profile=1)
+    env.context_patch.CopyFrom(
+        axcp_pb2.ContextPatch(
+            context_id="ctx",
+            base_version=1,
+            ops=[axcp_pb2.DeltaOp(op=axcp_pb2.DeltaOp.ADD, path="/message", data=b"ping", ts=1)],
+        )
+    )
+    return env
+
+
+def test_quic_transport_signed_envelope_roundtrip(tmp_path: Path) -> None:
+    asyncio.run(_signed_envelope_roundtrip(tmp_path))
+
+
+async def _signed_envelope_roundtrip(tmp_path: Path) -> None:
+    cert_file, key_file = _write_self_signed_cert(tmp_path)
+    alice = Agent(Identity.generate())
+    server_agent = Agent(Identity.generate())
+
+    async def handler(conn: QuicConnection) -> None:
+        incoming = await conn.receive_envelope(timeout=2)
+        server_agent.verify(incoming)
+
+        reply = server_agent.new_envelope(trace_id=incoming.trace_id)
+        reply.context_patch.CopyFrom(
+            axcp_pb2.ContextPatch(context_id="reply", base_version=2)
+        )
+        server_agent.sign_message(reply, recipient_did=incoming.sender_did)
+        await conn.send_envelope(reply)
+
+    server = await QuicServer.listen(
+        QuicServerConfig(host="127.0.0.1", port=0, cert_file=cert_file, key_file=key_file),
+        handler,
+    )
+    try:
+        host, port = server.address
+        client = await QuicClient.connect(
+            QuicClientConfig(host=host, port=port, server_name="localhost", insecure_skip_verify=True)
+        )
+        try:
+            env = _context_envelope()
+            alice.sign_message(env, recipient_did=server_agent.identity.did)
+            await client.send_envelope(env)
+
+            reply = await client.receive_envelope(timeout=2)
+            alice.verify(reply)
+            assert reply.context_patch.context_id == "reply"
+            assert reply.recipient_did == alice.identity.did
+        finally:
+            await client.close()
+    finally:
+        await server.close()
+
+
+def test_quic_transport_raw_message_big_endian_roundtrip(tmp_path: Path) -> None:
+    asyncio.run(_raw_message_big_endian_roundtrip(tmp_path))
+
+
+async def _raw_message_big_endian_roundtrip(tmp_path: Path) -> None:
+    cert_file, key_file = _write_self_signed_cert(tmp_path)
+
+    async def handler(conn: QuicConnection) -> None:
+        message = await conn.receive_message(timeout=2)
+        assert message == b"hello"
+        await conn.send_message(b"world")
+
+    server = await QuicServer.listen(
+        QuicServerConfig(host="127.0.0.1", port=0, cert_file=cert_file, key_file=key_file),
+        handler,
+    )
+    try:
+        host, port = server.address
+        client = await QuicClient.connect(
+            QuicClientConfig(host=host, port=port, server_name="localhost", insecure_skip_verify=True)
+        )
+        try:
+            await client.send_message(b"hello")
+            assert await client.receive_message(timeout=2) == b"world"
+        finally:
+            await client.close()
+    finally:
+        await server.close()
+
+
+def test_quic_transport_datagram_echo(tmp_path: Path) -> None:
+    asyncio.run(_datagram_echo(tmp_path))
+
+
+async def _datagram_echo(tmp_path: Path) -> None:
+    cert_file, key_file = _write_self_signed_cert(tmp_path)
+
+    def datagram_handler(protocol, data: bytes) -> None:
+        protocol.send_datagram(data)
+
+    async def handler(conn: QuicConnection) -> None:
+        await asyncio.sleep(0.2)
+
+    server = await QuicServer.listen(
+        QuicServerConfig(host="127.0.0.1", port=0, cert_file=cert_file, key_file=key_file),
+        handler,
+        datagram_handler=datagram_handler,
+    )
+    try:
+        host, port = server.address
+        client = await QuicClient.connect(
+            QuicClientConfig(host=host, port=port, server_name="localhost", insecure_skip_verify=True)
+        )
+        try:
+            await client.send_datagram(b"telemetry")
+            assert await client.receive_datagram(timeout=2) == b"telemetry"
+        finally:
+            await client.close()
+    finally:
+        await server.close()
+
+
+def test_quic_transport_rejects_oversized_message(tmp_path: Path) -> None:
+    asyncio.run(_rejects_oversized_message(tmp_path))
+
+
+async def _rejects_oversized_message(tmp_path: Path) -> None:
+    cert_file, key_file = _write_self_signed_cert(tmp_path)
+
+    async def handler(conn: QuicConnection) -> None:
+        with pytest.raises(TransportTimeoutError):
+            await conn.receive_message(timeout=0.2)
+
+    server = await QuicServer.listen(
+        QuicServerConfig(host="127.0.0.1", port=0, cert_file=cert_file, key_file=key_file),
+        handler,
+    )
+    try:
+        host, port = server.address
+        client = await QuicClient.connect(
+            QuicClientConfig(
+                host=host,
+                port=port,
+                server_name="localhost",
+                insecure_skip_verify=True,
+                max_frame_size=4,
+            )
+        )
+        try:
+            with pytest.raises(TransportFrameError):
+                await client.send_message(b"too-large")
+        finally:
+            await client.close()
+    finally:
+        await server.close()


### PR DESCRIPTION
## Summary
- Add `axcp.transport` with async QUIC client/server support backed by `aioquic`.
- Preserve Go SDK framing explicitly: raw messages use 4-byte big-endian length prefixes; protobuf envelopes use 4-byte little-endian length prefixes.
- Add QUIC DATAGRAM send/receive helpers for telemetry-sized payloads.
- Keep TLS verification enabled by default; self-signed local tests must opt into `insecure_skip_verify=True` explicitly.
- Add signed-envelope, raw-message, datagram, and oversized-frame transport tests plus a secure QUIC echo example.
- Update Python SDK docs and getting-started docs now that transport is available.

## Validation
- `PYTHONPATH=$PWD /tmp/axcp-python-sdk-venv/bin/python -m pytest -q scripts gateway sdk/python/tests`
- `/tmp/axcp-python-sdk-venv/bin/python -m grpc_tools.protoc -I=proto --python_out=proto proto/axcp.proto && /tmp/axcp-python-sdk-venv/bin/python -m grpc_tools.protoc -I=proto --python_out=sdk/python/src/axcp/pb proto/axcp.proto && git diff --exit-code proto/axcp_pb2.py sdk/python/src/axcp/pb/axcp_pb2.py`
- `/tmp/axcp-python-sdk-venv/bin/python -m build sdk/python --outdir /tmp/axcp-python-dist`
- `/tmp/axcp-python-sdk-venv/bin/python -m compileall -q sdk/python/src sdk/python/examples && git diff --check`
- `(cd sdk/go && go test ./...)`
- `(cd edge/gateway && go test ./...)`
- `(cd edge/rpi-agent && go test ./...)`
- `(cd sdk/rust && cargo fmt --all --check && cargo test --quiet)`
