### PR TITLE
[codex] Add SDK release readiness checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,12 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
 
+  # 5️⃣ npm (TypeScript SDK)
+  - package-ecosystem: "npm"
+    directory: "/sdk/typescript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
 # No cosmetic version bumps, only CVE patches.
 # Max 1 PR per ecosystem per week.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: pytest -q scripts gateway sdk/python/tests
 
+      - name: SDK release-readiness check
+        run: python scripts/verify_sdk_release_readiness.py
+
       - name: QUIC RTT micro-bench
         if: ${{ github.actor != 'dependabot[bot]' }}
         run: python bench/quic/rtt_bench.py 20

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This specification defines:
 | [Python SDK](sdk/python/README.md) | Core Python SDK for DID identity, signing, verification, replay, and profile negotiation |
 | [TypeScript SDK](sdk/typescript/README.md) | Core TypeScript SDK for DID identity, signing, verification, replay, and profile negotiation |
 | [TypeScript Transport](docs/typescript-transport.md) | TypeScript stream framing, TLS adapter, and QUIC adapter decision notes |
+| [SDK Release Readiness](docs/sdk-release-readiness.md) | Cross-SDK parity vector, package gates, and release checklist |
 
 ## What's New in v1.0
 

--- a/docs/sdk-release-readiness.md
+++ b/docs/sdk-release-readiness.md
@@ -1,0 +1,52 @@
+# SDK Release Readiness
+
+This document defines the pre-release contract for public AXCP SDK packages.
+
+## Release Scope
+
+The public package set currently covers:
+
+- Go SDK: reference implementation in `sdk/go`
+- Python SDK: Secure Baseline core plus QUIC transport in `sdk/python`
+- TypeScript SDK: Secure Baseline core plus stream/TLS transport in `sdk/typescript`
+- Rust SDK: experimental telemetry adapter, not a canonical transport SDK
+
+## Cross-SDK Parity
+
+Python and TypeScript must both pass the shared Secure Baseline vector in
+`testdata/sdk/secure_baseline_vector.json`.
+
+The vector locks:
+
+- deterministic Ed25519 seed and `did:key`
+- context patch payload
+- canonical signing payload bytes
+- DID auth transcript bytes
+- detached signature bytes
+- full encoded envelope bytes
+
+Any change to canonical serialization or transcript construction must update the
+fixture intentionally and should be reviewed as a protocol compatibility change.
+
+## Local Gates
+
+Run these before any public package publication:
+
+```bash
+python scripts/verify_sdk_release_readiness.py
+PYTHONPATH=$PWD python -m pytest -q scripts gateway sdk/python/tests
+(cd sdk/typescript && npm ci && npm test && npm run typecheck && npm pack --dry-run)
+(cd sdk/go && go test ./...)
+(cd edge/gateway && go test ./...)
+(cd edge/rpi-agent && go test ./...)
+(cd sdk/rust && cargo fmt --all --check && cargo test --quiet)
+git diff --check
+```
+
+## Publication Notes
+
+- Do not publish packages directly from an unreviewed branch.
+- Publish only from a signed/tagged release commit after CI is green.
+- Keep Python and TypeScript versions aligned while both packages are pre-1.0.
+- Keep QUIC for TypeScript as an optional adapter until the runtime dependency
+  is stable enough for public SDK users.

--- a/scripts/verify_sdk_release_readiness.py
+++ b/scripts/verify_sdk_release_readiness.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Release-readiness checks for public AXCP SDK packages."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VECTOR_PATH = ROOT / "testdata" / "sdk" / "secure_baseline_vector.json"
+PYPROJECT_PATH = ROOT / "sdk" / "python" / "pyproject.toml"
+NPM_PACKAGE_PATH = ROOT / "sdk" / "typescript" / "package.json"
+DEPENDABOT_PATH = ROOT / ".github" / "dependabot.yml"
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors.extend(check_vector())
+    errors.extend(check_python_package())
+    errors.extend(check_typescript_package())
+    errors.extend(check_dependabot())
+
+    if errors:
+        for error in errors:
+            print(f"release-readiness: {error}", file=sys.stderr)
+        return 1
+    print("release-readiness: ok")
+    return 0
+
+
+def check_vector() -> list[str]:
+    errors: list[str] = []
+    vector = json.loads(VECTOR_PATH.read_text(encoding="utf-8"))
+    required_top_level = {
+        "name",
+        "protocol_version",
+        "profile",
+        "trace_id",
+        "recipient_did",
+        "timestamp_ms",
+        "sequence",
+        "identity",
+        "context_patch",
+        "expected",
+    }
+    missing = required_top_level - vector.keys()
+    if missing:
+        errors.append(f"{VECTOR_PATH} missing keys: {sorted(missing)}")
+
+    identity = vector.get("identity", {})
+    seed = identity.get("private_seed_hex", "")
+    if len(seed) != 64:
+        errors.append("secure baseline vector private_seed_hex must be 32 bytes in hex")
+    if not identity.get("did", "").startswith("did:key:z"):
+        errors.append("secure baseline vector identity.did must be did:key base58btc")
+
+    expected = vector.get("expected", {})
+    for key in ("signing_payload_b64", "auth_transcript_b64", "signature_b64", "envelope_b64"):
+        if not expected.get(key):
+            errors.append(f"secure baseline vector expected.{key} is required")
+    return errors
+
+
+def check_python_package() -> list[str]:
+    errors: list[str] = []
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    project = pyproject.get("project", {})
+    if project.get("name") != "axcp":
+        errors.append("Python package name must remain axcp")
+    if project.get("license") != "Apache-2.0":
+        errors.append("Python SDK license must be Apache-2.0")
+    if not project.get("readme"):
+        errors.append("Python SDK must declare a README")
+    dependencies = set(project.get("dependencies", []))
+    for required in ("protobuf>=6.31.1", "PyNaCl>=1.5.0"):
+        if required not in dependencies:
+            errors.append(f"Python SDK missing dependency {required}")
+    package_data = pyproject.get("tool", {}).get("setuptools", {}).get("package-data", {})
+    if "py.typed" not in package_data.get("axcp", []):
+        errors.append("Python SDK must package py.typed")
+    return errors
+
+
+def check_typescript_package() -> list[str]:
+    errors: list[str] = []
+    package = json.loads(NPM_PACKAGE_PATH.read_text(encoding="utf-8"))
+    if package.get("name") != "@tradephantom/axcp":
+        errors.append("TypeScript package name must remain @tradephantom/axcp")
+    if package.get("license") != "Apache-2.0":
+        errors.append("TypeScript SDK license must be Apache-2.0")
+    exports = package.get("exports", {})
+    for subpath in (".", "./pb", "./transport"):
+        if subpath not in exports:
+            errors.append(f"TypeScript SDK missing export {subpath}")
+    files = set(package.get("files", []))
+    if "dist/src" not in files or "README.md" not in files:
+        errors.append("TypeScript SDK files must include dist/src and README.md")
+    scripts = package.get("scripts", {})
+    for script in ("build", "test", "typecheck", "prepack"):
+        if script not in scripts:
+            errors.append(f"TypeScript SDK missing npm script {script}")
+    return errors
+
+
+def check_dependabot() -> list[str]:
+    text = DEPENDABOT_PATH.read_text(encoding="utf-8")
+    errors: list[str] = []
+    if 'package-ecosystem: "npm"' not in text:
+        errors.append("Dependabot must track npm dependencies")
+    if 'directory: "/sdk/typescript"' not in text:
+        errors.append("Dependabot npm entry must target /sdk/typescript")
+    return errors
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/tests/test_envelope.py
+++ b/sdk/python/tests/test_envelope.py
@@ -1,5 +1,7 @@
 import base64
+import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +12,7 @@ from axcp.envelope import (
     decode_envelope,
     encode_envelope,
     new_envelope,
+    sign_envelope,
     signing_payload,
     verify_envelope,
 )
@@ -21,6 +24,8 @@ from axcp.errors import (
 )
 from axcp.pb import axcp_pb2
 
+VECTOR_PATH = Path(__file__).resolve().parents[3] / "testdata" / "sdk" / "secure_baseline_vector.json"
+
 
 def _context_envelope():
     env = new_envelope(trace_id="trace-123", profile=1)
@@ -31,6 +36,23 @@ def _context_envelope():
             ops=[axcp_pb2.DeltaOp(op=axcp_pb2.DeltaOp.ADD, path="/x", data=b"1", ts=1)],
         )
     )
+    return env
+
+
+def _vector_envelope(vector: dict) -> axcp_pb2.AxcpEnvelope:
+    env = new_envelope(trace_id=vector["trace_id"], profile=vector["profile"])
+    patch = vector["context_patch"]
+    env.context_patch.context_id = patch["context_id"]
+    env.context_patch.base_version = patch["base_version"]
+    for op in patch["ops"]:
+        env.context_patch.ops.append(
+            axcp_pb2.DeltaOp(
+                op=getattr(axcp_pb2.DeltaOp, op["op"]),
+                path=op["path"],
+                data=base64.b64decode(op["data_b64"]),
+                ts=op["ts"],
+            )
+        )
     return env
 
 
@@ -182,3 +204,25 @@ def test_agent_verifies_non_key_sender_with_resolver() -> None:
 
     alice.sign_message(env, recipient_did=bob.identity.did)
     bob.verify(env)
+
+
+def test_shared_secure_baseline_vector_matches_python_sdk() -> None:
+    vector = json.loads(VECTOR_PATH.read_text(encoding="utf-8"))
+    identity = Identity.from_seed(bytes.fromhex(vector["identity"]["private_seed_hex"]))
+    env = _vector_envelope(vector)
+
+    sign_envelope(
+        env,
+        identity,
+        recipient_did=vector["recipient_did"],
+        sequence=vector["sequence"],
+        timestamp_ms=vector["timestamp_ms"],
+    )
+
+    expected = vector["expected"]
+    assert identity.did == vector["identity"]["did"]
+    assert base64.b64encode(identity.public_key).decode("ascii") == vector["identity"]["public_key_b64"]
+    assert base64.b64encode(signing_payload(env)).decode("ascii") == expected["signing_payload_b64"]
+    assert base64.b64encode(build_auth_transcript(env)).decode("ascii") == expected["auth_transcript_b64"]
+    assert base64.b64encode(env.signature).decode("ascii") == expected["signature_b64"]
+    assert base64.b64encode(encode_envelope(env)).decode("ascii") == expected["envelope_b64"]

--- a/sdk/typescript/tests/envelope.test.ts
+++ b/sdk/typescript/tests/envelope.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   Agent,
   DID_AUTH_TRANSCRIPT_VERSION,
@@ -21,6 +22,37 @@ import {
   type AxcpEnvelope,
 } from "../src/index.js";
 
+const VECTOR_URL = new URL("../../../../testdata/sdk/secure_baseline_vector.json", import.meta.url);
+
+interface SecureBaselineVector {
+  readonly trace_id: string;
+  readonly profile: number;
+  readonly recipient_did: string;
+  readonly timestamp_ms: number;
+  readonly sequence: number;
+  readonly identity: {
+    readonly private_seed_hex: string;
+    readonly did: string;
+    readonly public_key_b64: string;
+  };
+  readonly context_patch: {
+    readonly context_id: string;
+    readonly base_version: number;
+    readonly ops: Array<{
+      readonly op: keyof typeof DeltaOpType;
+      readonly path: string;
+      readonly data_b64: string;
+      readonly ts: number;
+    }>;
+  };
+  readonly expected: {
+    readonly signing_payload_b64: string;
+    readonly auth_transcript_b64: string;
+    readonly signature_b64: string;
+    readonly envelope_b64: string;
+  };
+}
+
 function contextEnvelope(): AxcpEnvelope {
   const envelope = newEnvelope({ traceId: "trace-123", profile: 1 });
   envelope.contextPatch = {
@@ -36,6 +68,25 @@ function contextEnvelope(): AxcpEnvelope {
     ],
   };
   return envelope;
+}
+
+function vectorEnvelope(vector: SecureBaselineVector): AxcpEnvelope {
+  const envelope = newEnvelope({ traceId: vector.trace_id, profile: vector.profile });
+  envelope.contextPatch = {
+    contextId: vector.context_patch.context_id,
+    baseVersion: vector.context_patch.base_version,
+    ops: vector.context_patch.ops.map((op) => ({
+      op: DeltaOpType[op.op],
+      path: op.path,
+      data: Buffer.from(op.data_b64, "base64"),
+      ts: op.ts,
+    })),
+  };
+  return envelope;
+}
+
+function loadVector(): SecureBaselineVector {
+  return JSON.parse(readFileSync(VECTOR_URL, "utf8")) as SecureBaselineVector;
 }
 
 describe("envelope", () => {
@@ -181,46 +232,37 @@ describe("envelope", () => {
     await bob.verify(envelope);
   });
 
-  it("matches the Python SDK canonical signature vector", () => {
-    const identity = Identity.fromSeed(Uint8Array.from([...Array(32).keys()]));
-    const envelope = contextEnvelope();
-    envelope.traceId = "trace-vector";
+  it("matches the shared Secure Baseline canonical signature vector", () => {
+    const vector = loadVector();
+    const identity = Identity.fromSeed(Buffer.from(vector.identity.private_seed_hex, "hex"));
+    const envelope = vectorEnvelope(vector);
 
     signEnvelope(envelope, identity, {
-      recipientDid: "did:example:bob",
-      sequence: 42,
-      timestampMs: 1_700_000_000_123,
+      recipientDid: vector.recipient_did,
+      sequence: vector.sequence,
+      timestampMs: vector.timestamp_ms,
     });
 
-    assert.equal(identity.did, "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd");
+    assert.equal(identity.did, vector.identity.did);
     assert.deepEqual(
       Buffer.from(identity.publicKey),
-      Buffer.from("A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=", "base64"),
+      Buffer.from(vector.identity.public_key_b64, "base64"),
     );
     assert.deepEqual(
       Buffer.from(signingPayload(envelope)),
-      Buffer.from("CAESDHRyYWNlLXZlY3RvchgBIhIKA2N0eBAHGgkSAi94GgExIAE=", "base64"),
+      Buffer.from(vector.expected.signing_payload_b64, "base64"),
     );
     assert.deepEqual(
       Buffer.from(buildAuthTranscript(envelope)),
-      Buffer.from(
-        "QVhDUC1ESUQtQVVUSC12MQpkaWQ6a2V5Ono2TWtlaFJnZjd5SmJnYUdmWXNkb0FzS2RCUEUzZGoyQ1lob3dRZGNqcVNKZ3ZWZApkaWQ6ZXhhbXBsZTpib2IKQ0FFU0RIUnlZV05sTFhabFkzUnZjaGdCSWhJS0EyTjBlQkFIR2drU0FpOTRHZ0V4SUFFPQoyMDIzLTExLTE0VDIyOjEzOjIwWg==",
-        "base64",
-      ),
+      Buffer.from(vector.expected.auth_transcript_b64, "base64"),
     );
     assert.deepEqual(
       Buffer.from(envelope.signature ?? new Uint8Array()),
-      Buffer.from(
-        "PJQax44TKAkSXgLmHviGE3ntoFqQ9h00Lk+NfGvq35uKjPVc9wV9BLRg6ByvhIHDYbaddAsSkcTtjcpm9xlsAg==",
-        "base64",
-      ),
+      Buffer.from(vector.expected.signature_b64, "base64"),
     );
     assert.deepEqual(
       Buffer.from(encodeEnvelope(envelope)),
-      Buffer.from(
-        "CAESDHRyYWNlLXZlY3RvchgBIhIKA2N0eBAHGgkSAi94GgExIAGiAThkaWQ6a2V5Ono2TWtlaFJnZjd5SmJnYUdmWXNkb0FzS2RCUEUzZGoyQ1lob3dRZGNqcVNKZ3ZWZKgB+9CV/7wxsAEqugEPZGlkOmV4YW1wbGU6Ym9iogZAPJQax44TKAkSXgLmHviGE3ntoFqQ9h00Lk+NfGvq35uKjPVc9wV9BLRg6ByvhIHDYbaddAsSkcTtjcpm9xlsAg==",
-        "base64",
-      ),
+      Buffer.from(vector.expected.envelope_b64, "base64"),
     );
   });
 });

--- a/testdata/sdk/secure_baseline_vector.json
+++ b/testdata/sdk/secure_baseline_vector.json
@@ -1,0 +1,33 @@
+{
+  "name": "secure-baseline-context-patch-v1",
+  "description": "AXCP Secure Baseline deterministic signing vector shared by Python and TypeScript SDK tests.",
+  "protocol_version": 1,
+  "profile": 1,
+  "trace_id": "trace-vector",
+  "recipient_did": "did:example:bob",
+  "timestamp_ms": 1700000000123,
+  "sequence": 42,
+  "identity": {
+    "private_seed_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "did": "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd",
+    "public_key_b64": "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="
+  },
+  "context_patch": {
+    "context_id": "ctx",
+    "base_version": 7,
+    "ops": [
+      {
+        "op": "ADD",
+        "path": "/x",
+        "data_b64": "MQ==",
+        "ts": 1
+      }
+    ]
+  },
+  "expected": {
+    "signing_payload_b64": "CAESDHRyYWNlLXZlY3RvchgBIhIKA2N0eBAHGgkSAi94GgExIAE=",
+    "auth_transcript_b64": "QVhDUC1ESUQtQVVUSC12MQpkaWQ6a2V5Ono2TWtlaFJnZjd5SmJnYUdmWXNkb0FzS2RCUEUzZGoyQ1lob3dRZGNqcVNKZ3ZWZApkaWQ6ZXhhbXBsZTpib2IKQ0FFU0RIUnlZV05sTFhabFkzUnZjaGdCSWhJS0EyTjBlQkFIR2drU0FpOTRHZ0V4SUFFPQoyMDIzLTExLTE0VDIyOjEzOjIwWg==",
+    "signature_b64": "PJQax44TKAkSXgLmHviGE3ntoFqQ9h00Lk+NfGvq35uKjPVc9wV9BLRg6ByvhIHDYbaddAsSkcTtjcpm9xlsAg==",
+    "envelope_b64": "CAESDHRyYWNlLXZlY3RvchgBIhIKA2N0eBAHGgkSAi94GgExIAGiAThkaWQ6a2V5Ono2TWtlaFJnZjd5SmJnYUdmWXNkb0FzS2RCUEUzZGoyQ1lob3dRZGNqcVNKZ3ZWZKgB+9CV/7wxsAEqugEPZGlkOmV4YW1wbGU6Ym9iogZAPJQax44TKAkSXgLmHviGE3ntoFqQ9h00Lk+NfGvq35uKjPVc9wV9BLRg6ByvhIHDYbaddAsSkcTtjcpm9xlsAg=="
+  }
+}


### PR DESCRIPTION
## What changed

- Added a shared Secure Baseline signing vector under `testdata/sdk`.
- Wired Python and TypeScript envelope tests to consume the same canonical vector.
- Added `scripts/verify_sdk_release_readiness.py` and runs it in CI after the Python suite.
- Documented SDK release gates in `docs/sdk-release-readiness.md` and linked it from the README.
- Added Dependabot coverage for the TypeScript SDK npm dependencies.

## Why

Phase 5 moves the new Python and TypeScript SDKs from implementation work toward release readiness. The shared vector gives us a concrete cross-SDK compatibility guard for canonical payload serialization, DID auth transcript construction, signatures, and encoded envelopes.

## Validation

- `PYTHONPATH=$PWD /tmp/axcp-python-sdk-venv/bin/python -m pytest -q scripts gateway sdk/python/tests`
- `/tmp/axcp-python-sdk-venv/bin/python scripts/verify_sdk_release_readiness.py`
- `(cd sdk/typescript && npm ci && npm test && npm run typecheck && npm pack --dry-run)`
- `(cd sdk/go && go test ./...)`
- `(cd edge/gateway && go test ./...)`
- `(cd edge/rpi-agent && go test ./...)`
- `(cd sdk/rust && cargo fmt --all --check && cargo test --quiet)`
- `git diff --check`
