### PR TITLE
[codex] Declare Node types for TypeScript SDK

### DIFF
--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## What changed

- Declares `types: ["node"]` in the TypeScript SDK `tsconfig.json`.

## Why

Dependabot PR #214 (`typescript` 5.9.3 -> 6.0.3) fails during `npm run typecheck` because TypeScript 6 no longer resolves the SDK's Node globals and `node:*` module typings implicitly from the current config. The SDK already depends on `@types/node`; the missing piece is making that ambient type surface explicit.

This keeps the package Node-targeted and avoids broadening `lib` to DOM just to recover globals such as `console`, `TextEncoder`, `Buffer`, `node:fs`, and `ImportMeta.url`.

## Validation

- `(cd sdk/typescript && npm ci && npm run typecheck && npm test && npm pack --dry-run)`
- `(cd sdk/typescript && npm exec --package=typescript@6.0.3 -- tsc -p tsconfig.json --noEmit)`
- `git diff --check`
