### PR TITLE
[codex] Bump TypeScript SDK compiler to 6.0.3

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.15.21",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20.10"
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -49,6 +49,6 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.21",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## What changed

- Bumps the TypeScript SDK compiler from `typescript` 5.9.3 to 6.0.3.
- Keeps the same package-lock update Dependabot proposed in #214, but lands it from a maintainer branch with DCO sign-off.

## Why

Dependabot PR #214 originally failed because TypeScript 6 stopped resolving the SDK's Node type surface under the previous `tsconfig.json`. PR #216 fixed that by declaring `types: ["node"]`; after updating #214 against the new main, all Actions passed.

#214 is still blocked by the external `license/cla` status for `dependabot[bot]`, while this repository documents DCO instead of a traditional CLA. This PR carries the same dependency update without the bot CLA blocker.

## Validation

- `(cd sdk/typescript && npm run typecheck && npm test && npm pack --dry-run)`
- `git diff --check`

Supersedes #214.
