### PR TITLE
chore: tighten repository governance hygiene

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,19 @@
-### Checklist
+## Summary
 
-* [ ] Title follows `type(scope): subject` convention
-* [ ] No source or manifest files modified
-* [ ] Docs and/or community assets updated
-* [ ] All CI jobs passing
+Describe the change and the problem it solves.
 
----
+## Validation
 
-> **N.B.** No source code or manifest files modified – merge safe, no publish triggered.
+List the local commands or CI jobs used to verify the change.
+
+## Risk
+
+Call out compatibility, security, release, or migration impact. Write `None` if
+there is no material risk.
+
+## Checklist
+
+- [ ] Title follows `type(scope): subject`
+- [ ] Commits include `Signed-off-by` for DCO compliance
+- [ ] Public docs or examples were updated when behavior changed
+- [ ] Relevant CI jobs pass

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,47 +1,90 @@
-# Minimal-impact Dependabot configuration (security patches only)
+# Low-noise dependency maintenance for AXCP Core.
+#
+# This file controls scheduled version-update PRs. GitHub Dependabot alerts and
+# security updates must remain enabled in repository settings for CVE-driven
+# updates. Python lower bounds are maintained manually to avoid unnecessary
+# compatibility breaks from broad minimum-version bumps.
 version: 2
 updates:
-  # 1️⃣ GitHub Actions – critical security patches & runner deprecations
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
 
-  # --- Cargo (SDK Rust crate) ---
   - package-ecosystem: "cargo"
     directory: "/sdk/rust"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
+      day: "monday"
+      time: "08:15"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
-  # --- Cargo (legacy v0.3 crate) ---
   - package-ecosystem: "cargo"
     directory: "/v0.3/rust/axcp-rs"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
+      day: "monday"
+      time: "08:30"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "rust"
+      - "legacy"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
-  # 3️⃣ Go modules
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
+      day: "monday"
+      time: "08:45"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
 
-  # 4️⃣ Pip (Python)
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
-
-  # 5️⃣ npm (TypeScript SDK)
   - package-ecosystem: "npm"
     directory: "/sdk/typescript"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
-
-# No cosmetic version bumps, only CVE patches.
-# Max 1 PR per ecosystem per week.
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "typescript"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@
 # This workflow runs the Core test suite independently of Advanced/Enterprise.
 # It validates: Go SDK, Python bindings, Gateway telemetry, Rust SDK, examples.
 #
-# Required checks: "Test Go", "Test Python" (defined in branch protection)
+# Recommended required checks: Test Go, Test Python, Test TypeScript,
+# Test Gateway Telemetry, Test RPi Agent, Check Examples.
 # =============================================================================
 
 name: AXCP CI
@@ -30,7 +31,7 @@ env:
   PROTOC_GEN_GO_VERSION: 'v1.36.11'
 
 # ------------------------------------------------------------
-# 1️⃣  GO – unit tests  (verde)
+# 1. Go unit tests
 # ------------------------------------------------------------
 jobs:
   test-go:
@@ -115,7 +116,7 @@ jobs:
           cache: true
 
       - name: Set-up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -153,7 +154,7 @@ jobs:
         run: go test ./... -bench=. -benchtime=1x -benchmem
 
 # ------------------------------------------------------------
-# 2b TypeScript SDK Core
+# 2b. TypeScript SDK core
 # ------------------------------------------------------------
   test-typescript:
     name: Test TypeScript
@@ -185,7 +186,7 @@ jobs:
         run: npm pack --dry-run
 
 # ------------------------------------------------------------ 
-# 3️⃣  GATEWAY TELEMETRY (integrazione) – verde
+# 3. Gateway telemetry integration
 # ------------------------------------------------------------
   test-gateway-telemetry:
     name: Test Gateway Telemetry
@@ -219,7 +220,7 @@ jobs:
           (cd edge/gateway && go test -v -race ./internal/metrics/... -run TestPrometheusMetrics)
 
 # ------------------------------------------------------------
-# 4️⃣  RPI AGENT (Issue 21c) – usa stubs rigenerati & workspace
+# 4. RPi Agent using generated stubs and a Go workspace
 # ------------------------------------------------------------
   test-rpi-agent:
     name: Test RPi Agent
@@ -247,13 +248,13 @@ jobs:
           go work init ./sdk/go ./edge/rpi-agent || true
           go work use  ./sdk/go ./edge/rpi-agent
 
-      # ── Esegui test agent ---------------------------------------
+      # Run agent tests.
       - name: Run rpi-agent tests
         working-directory: edge/rpi-agent
         run: go test -v -race ./...
 
 # ------------------------------------------------------------ 
-# 5️⃣  EXAMPLES – build check
+# 5. Examples build check
 # ------------------------------------------------------------
   check-examples:
     name: Check Examples


### PR DESCRIPTION
## Summary

- align Dependabot scheduled version updates with a low-noise public maintenance policy
- remove the misleading security-only comments and stop broad Python lower-bound version PRs
- replace the PR template with a real summary/validation/risk/DCO template
- update `actions/setup-python` to v6 and clean up CI comments

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## Risk\n\nLow. This changes repository automation and CI metadata only; no runtime code or SDK API changes.