### PR TITLE
chore: update artifact actions policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "cargo"
     directory: "/sdk/rust"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
       # ── Download protobuf artifacts from test-go job ──────────────
       - name: Download protobuf artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: go-protobuf-stubs
           path: sdk/go/internal/pb/
@@ -197,7 +197,7 @@ jobs:
 
       # ── Download protobuf artifacts from test-go job ──────────────
       - name: Download protobuf artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: go-protobuf-stubs
           path: sdk/go/internal/pb/
@@ -231,7 +231,7 @@ jobs:
 
       # ── Download protobuf artifacts from test-go job ──────────────
       - name: Download protobuf artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: go-protobuf-stubs
           path: sdk/go/internal/pb/


### PR DESCRIPTION
## Summary

- update `actions/download-artifact` from v4 to v8 in the AXCP CI artifact reuse steps
- add a Dependabot guardrail so future GitHub Actions major bumps are handled manually instead of opening CLA-pending bot PRs
- replace Dependabot PR #219 with a maintainer-authored DCO commit

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## Risk\n\nMedium-low. This changes CI action versions only; Dependabot PR #219 already passed the full AXCP CI matrix with the same `download-artifact` update.