### PR TITLE
chore: limit Go Dependabot version noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,11 @@ updates:
       - "go"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "npm"
     directory: "/sdk/typescript"


### PR DESCRIPTION
## Summary

- restrict scheduled Go module version-update PRs to patch updates
- keep Go minor/major dependency changes manual because recent bot PRs required newer Go baselines than the repo currently supports
- preserve security-alert handling through repository Dependabot security settings

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## Risk\n\nLow. This changes Dependabot scheduling policy only; it reduces noisy PRs that are incompatible with the current Go 1.23.4 baseline.