### PR TITLE
ci: run rust checks on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # AXCP Core CI - Standalone Pipeline
 # =============================================================================
 # This workflow runs the Core test suite independently of Advanced/Enterprise.
-# It validates: Go SDK, Python bindings, Gateway telemetry, Rust SDK, examples.
+# It validates: Go SDK, Python bindings, Gateway telemetry, TypeScript SDK, examples.
 #
 # Recommended required checks: Test Go, Test Python, Test TypeScript,
 # Test Gateway Telemetry, Test RPi Agent, Check Examples.

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,13 +2,11 @@ name: Rust CI
 
 on:
   push:
-    paths:
-      - 'sdk/rust/**'
-      - '.github/workflows/rust-ci.yml'
+    branches:
+      - main
   pull_request:
-    paths:
-      - 'sdk/rust/**'
-      - '.github/workflows/rust-ci.yml'
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * *'   # daily
 


### PR DESCRIPTION
## Summary\n- Run Rust CI on every pull request to main instead of only Rust-path changes, so the Rust jobs can safely become required branch-protection checks.\n- Correct the AXCP CI header comment to reflect that TypeScript, not Rust, is validated by that workflow.\n\n## Validation\n- git diff --check\n\nSigned-off-by: TradePhantom <dev@tradephantom.com>