### PR TITLE
chore: expand dependabot go module coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,12 +80,132 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
 
+  - package-ecosystem: "gomod"
+    directory: "/edge/gateway"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "gateway"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "gomod"
+    directory: "/edge/rpi-agent"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "rpi-agent"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "gomod"
+    directory: "/sdk/go"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "sdk"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "gomod"
+    directory: "/sdk/go/netquic"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:45"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "netquic"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "gomod"
+    directory: "/sdk/go/examples/telemetry_example"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "examples"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "gomod"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:15"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "tests"
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
   - package-ecosystem: "npm"
     directory: "/sdk/typescript"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
+      time: "10:30"
       timezone: "Europe/Rome"
     open-pull-requests-limit: 1
     labels:


### PR DESCRIPTION
## Summary\n- Add Dependabot version-update coverage for all active Go modules outside the repository root.\n- Keep low-noise patch-only update policy for Go modules and stagger weekly schedules.\n- Move TypeScript scheduled updates later to avoid overlapping the new Go module windows.\n\n## Validation\n- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'\n- verified configured directories exist\n- git diff --check\n\nSigned-off-by: TradePhantom <dev@tradephantom.com>