### PR TITLE
[codex] align enterprise privacy controls docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For organizations requiring advanced capabilities, TradePhantom LLC offers comme
 | Tier | Key Features |
 |------|--------------|
 | **AXCP Advanced** | mTLS with DID-bound certificates, Hardware attestation (SGX/SEV), Rate limiting middleware, Context-Sync (CRDT), Differential Privacy (optional) |
-| **AXCP Enterprise** | Secure telemetry ingestion, Differential Privacy (mandatory), PII filtering & redaction, Compliance reporting (GDPR/HIPAA/SOC2), Ed25519 audit trails, Prometheus & OpenTelemetry metrics |
+| **AXCP Enterprise** | Secure telemetry ingestion, configurable Differential Privacy controls, PII filtering & redaction, Compliance reporting (GDPR/HIPAA/SOC2), Ed25519 audit trails, Prometheus & OpenTelemetry metrics |
 
 For licensing inquiries: [enterprise@getaxcp.com](mailto:enterprise@getaxcp.com)
 

--- a/docs/licensing/commercial-use.md
+++ b/docs/licensing/commercial-use.md
@@ -58,7 +58,7 @@ Advanced features require a commercial license from TradePhantom LLC.
 - Structured logging
 
 **AXCP Enterprise ($$)**
-- Differential Privacy (mandatory enforcement)
+- Configurable Differential Privacy controls
 - PII filtering & redaction
 - Compliance reporting (GDPR, HIPAA, SOC2)
 - Audit trails (Merkle tree verified)

--- a/docs/licensing/faq.md
+++ b/docs/licensing/faq.md
@@ -12,7 +12,7 @@
 **A:**
 - **Core** (Apache 2.0): Full protocol implementation with DID authentication, Ed25519 signatures, QUIC transport, and basic telemetry
 - **Advanced** (Commercial): Adds Context-Sync, mTLS, SGX/SEV enclaves, differential privacy options
-- **Enterprise** (Commercial): Adds mandatory privacy enforcement, compliance tools, audit trails, TRI-AI orchestration, dedicated support
+- **Enterprise** (Commercial): Adds configurable privacy controls, compliance tools, audit trails, TRI-AI orchestration, dedicated support
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaces stale "mandatory Differential Privacy" language in the public Core README and licensing docs.
- Describes Enterprise privacy controls as configurable, matching the current commercial-tier behavior.

## Why
Differential Privacy is no longer positioned as universally mandatory because some regulated or financial workflows require exact numeric payloads. The public Core docs should reflect configurable Enterprise privacy controls without implying automatic data mutation.

## Validation
- `rg -n "Differential Privacy \\(mandatory\\)|mandatory privacy enforcement|mandatory enforcement|DP mandatory" README.md docs -S || true`
- `git diff --check`
- `python3 scripts/verify_sdk_release_readiness.py`
