### PR TITLE
[codex] update CI actions for Node 24 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     name: Test Go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set-up Go
         uses: actions/setup-go@v6
@@ -100,7 +100,7 @@ jobs:
     needs: [test-go]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── Download protobuf artifacts from test-go job ──────────────
       - name: Download protobuf artifacts
@@ -160,10 +160,10 @@ jobs:
     name: Test TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set-up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -193,7 +193,7 @@ jobs:
     needs: [test-go]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── Download protobuf artifacts from test-go job ──────────────
       - name: Download protobuf artifacts
@@ -227,7 +227,7 @@ jobs:
     needs: [test-go]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── Download protobuf artifacts from test-go job ──────────────
       - name: Download protobuf artifacts
@@ -261,7 +261,7 @@ jobs:
     needs: [test-go]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set-up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -33,18 +33,15 @@ jobs:
             cache-key: nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install "${{ matrix.rust }}" --profile minimal --component rustfmt --component clippy
+          rustup default "${{ matrix.rust }}"
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -79,14 +76,12 @@ jobs:
     if: always()                # mostra esito anche se test fallisse
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       # --- documentation ---------------------------------
       - name: Build docs with warnings denied
@@ -97,11 +92,7 @@ jobs:
 
       # --- nightly toolchain per cargo-udeps --------------
       - name: Install nightly Rust (for udeps)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: false
+        run: rustup toolchain install nightly --profile minimal
 
       - name: Install cargo-udeps
         run: cargo +nightly install cargo-udeps --quiet --locked


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflow dependencies that emitted Node 20 deprecation warnings.
- Replaces `actions-rs/toolchain@v1` with direct `rustup` toolchain installation to remove deprecated `set-output` usage.
- Updates checkout/cache/setup-node actions to current Node 24-compatible major versions.

## Why
The Rust CI workflow was green but emitted deprecation warnings for Node 20-based actions and `set-output`. This keeps CI ahead of the upcoming GitHub runner default changes and avoids future workflow breakage.

## Validation
- `rg -n "actions-rs/toolchain|actions/checkout@v4|actions/cache@v4|actions/setup-node@v4|set-output" .github/workflows -S || true`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/rust-ci.yml`
- `git diff --check`
- `(cd sdk/rust && cargo fmt --all --check && cargo test --quiet)`
