### PR TITLE
Refresh Rust and TypeScript dependencies

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -141,9 +141,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -13,7 +13,7 @@
         "protobufjs": "^8.6.4"
       },
       "devDependencies": {
-        "@types/node": "^22.15.21",
+        "@types/node": "^22.20.0",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -48,7 +48,7 @@
     "protobufjs": "^8.6.4"
   },
   "devDependencies": {
-    "@types/node": "^22.15.21",
+    "@types/node": "^22.20.0",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- replace Dependabot PR #252 by bumping sdk/rust bytes lock entry to 1.12.0
- replace Dependabot PR #253 by bumping sdk/typescript @types/node to 22.20.0
- keep the same dependency changes under a TradePhantom-authored commit because #252/#253 are blocked by pending license/cla on Dependabot

## Verification
- cd sdk/rust && cargo test --verbose
- cd sdk/rust && cargo fmt --check
- cd sdk/typescript && npm test && npm run typecheck && npm pack --dry-run
- git diff --check
- git diff --cached --check