### PR TITLE
[codex] Align Core auth transcript docs and paper draft

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -92,19 +92,36 @@ The signature is computed over a **canonical transcript** that includes all auth
 **Format**:
 ```
 AXCP-DID-AUTH-v1
-<clientDID>
-<serverDID>
-<base64(challenge)>
+<senderDID>
+<recipientDID>
+<base64(canonicalSigningPayload)>
 <timestampRFC3339>
 ```
 
-**Important**: Do not construct transcripts manually. Use the SDK function:
+The canonical signing payload is the deterministic Protobuf encoding of the
+envelope after clearing detached authentication fields:
+
+- `sender_did`
+- `recipient_did`
+- `timestamp_ms`
+- `signature`
+- `attestation_proof`
+
+The replay `sequence` field remains covered by the signing payload. This means
+sequence tampering invalidates the signature before replay state is checked or
+mutated.
+
+**Important**: Do not construct envelope transcripts manually. Use the SDK
+envelope helper:
 
 ```go
-transcript := auth.BuildDIDAuthTranscript(clientDID, serverDID, challenge, timestamp)
+transcript, err := axcp.BuildAuthTranscript(envelope)
 ```
 
-This ensures the transcript matches the specification exactly.
+For lower-level integrations, `auth.BuildDIDAuthTranscript(senderDID,
+recipientDID, canonicalSigningPayload, timestamp)` remains the transcript
+primitive. Its third argument is the canonical signing payload bytes, not a
+standalone challenge in Secure Baseline envelope signing.
 
 ## Replay Protection
 
@@ -156,6 +173,7 @@ There is no retry logic for authentication failures. Implementations must **fail
 | Component | Location |
 |-----------|----------|
 | DID types and transcript | `sdk/go/auth/did.go` |
+| Envelope signing payload | `sdk/go/axcp/signature.go` |
 | Ed25519 operations | `sdk/go/auth/ed25519.go` |
 | Replay protection | `sdk/go/auth/replay.go` |
 | Session management | `sdk/go/auth/session.go` |

--- a/docs/paper/AXCP_Core_vNext_Paper_Draft.md
+++ b/docs/paper/AXCP_Core_vNext_Paper_Draft.md
@@ -1,0 +1,628 @@
+# AXCP Core vNext Paper Draft
+
+**Working title:** AXCP Core: Message-Level Identity, Authentication, and Replay Protection for Autonomous Agent Communication
+**Draft status:** Source draft for editorial review and LaTeX conversion
+**Target venue/artifact:** Updated Zenodo preprint replacing or versioning the February 2026 AXCP v1.0 paper
+**Prepared from repository state:** `tradephantomllc/axcp-spec` `main`, after PRs #254 and #255
+**Date:** 2026-07-05
+**Scope:** AXCP Core only, Apache 2.0 open-source repository
+
+---
+
+## Editorial Notes for Superbrain
+
+This document is not the final paper. It is the technical source draft to be refined into the final manuscript and LaTeX.
+
+The current Zenodo paper, published on 2026-02-04 as Version 1.0, describes AXCP as a secure communication protocol for autonomous AI agents and lists Go/Rust as the public implementation languages. The repository has since materially changed. The paper needs to reflect the current AXCP Core boundary and avoid claims that are no longer precise or that belong to commercial tiers.
+
+Important alignment decisions:
+
+1. AXCP Core is the public, Apache 2.0 protocol surface.
+2. Advanced and Enterprise are commercial/private tiers and should be mentioned only at a high level.
+3. Python and TypeScript SDKs are now part of the Core story and should no longer be described as "coming soon".
+4. Rust should be described carefully as an experimental telemetry adapter, not as an equal canonical Core transport SDK.
+5. The paper should not claim Differential Privacy is mandatory in Core or Enterprise. DP belongs to commercial controls and is configurable where implemented.
+6. The paper should avoid unpublished Enterprise details such as CBE internals, SAM issuer mechanics, ARCANA internals, licensing enforcement design, or production gateway deployment details.
+7. If performance numbers are included, they must be regenerated from the current repository and included as a dated benchmark table. Do not reuse old metrics without rerunning them.
+8. The paper should make the distinction clear: TLS secures a channel; AXCP Secure Baseline binds sender identity, recipient identity, canonical payload bytes, timestamp, and replay sequence at the message layer.
+
+Recommended paper version label: **v1.1** or **2026 revision**. The protocol spec remains **AXCP Core Specification v1.0 (Secure Baseline)** unless we intentionally publish a protocol-spec update.
+
+---
+
+## Version Synchronization Box
+
+Use this as the source of truth for the final manuscript metadata:
+
+| Field | Value |
+|---|---|
+| Paper version | AXCP Core Paper v1.1 / 2026 revision |
+| Protocol specification | AXCP Core Specification v1.0, Secure Baseline |
+| Repository | `tradephantomllc/axcp-spec` |
+| Repository state | `main` after transcript/spec/authentication alignment |
+| Publication target | Zenodo updated version under the existing concept DOI |
+| Core boundary | Apache 2.0 public repository; no Advanced/Enterprise code |
+| SDKs covered | Go, Python, TypeScript |
+| Rust status | Experimental telemetry adapter |
+| Performance claims | Omitted unless regenerated with current code, hardware, and commands |
+
+Do not use "vNext" in the final paper title. It is only the working filename for this draft.
+
+---
+
+## Abstract
+
+Autonomous AI agents increasingly coordinate across tools, services, gateways, and organizational boundaries. Existing agent integration protocols focus primarily on tool access, context exchange, or interoperability, while often delegating trust to the transport channel or to external identity infrastructure. AXCP, the Adaptive eXchange Context Protocol, addresses a narrower but critical problem: secure, verifiable communication between autonomous agents.
+
+AXCP Core defines a Secure Baseline profile for message-level authentication, replay protection, and deterministic interoperability. Each AXCP envelope carries a Decentralized Identifier (DID), an Ed25519 detached signature, a timestamp, and replay material such as a monotonic sequence number. The signed authentication transcript binds the sender, recipient, canonical payload bytes, timestamp, and sequence-sensitive replay semantics so that messages remain attributable and tamper-evident beyond the lifetime of a transport connection.
+
+This paper presents the current AXCP Core architecture, the Secure Baseline profile, the canonical signing model, replay protection requirements, cross-SDK interoperability guarantees, and the open-source implementation boundary. The current public repository provides Go, Python, and TypeScript Core SDKs with a shared Secure Baseline test vector that locks deterministic envelope encoding, DID authentication transcript bytes, Ed25519 signature bytes, and full encoded envelope bytes. Commercial features such as mTLS management, attestation, PII controls, compliance reporting, and advanced execution governance are outside the Core repository and are intentionally not part of this paper's implementation claims.
+
+AXCP is best understood as a security layer for agentic communication rather than a replacement for tool protocols. MCP defines how models and applications expose tools and context; A2A-style systems address agent interoperability and discovery; AXCP Core focuses on ensuring that agent messages are authenticated, replay-resistant, and verifiable across implementation languages.
+
+---
+
+## 1. Introduction
+
+Agentic systems are moving from single-process tool calls toward distributed workflows. A single task may involve a planning agent, a retrieval agent, a domain specialist, a gateway, a memory service, a telemetry collector, and one or more external tools. In this environment, communication itself becomes a security boundary.
+
+Traditional web security often assumes that TLS is sufficient for transport confidentiality and integrity. TLS is necessary, but it does not by itself answer several questions that matter in agentic networks:
+
+- Which agent authored this message?
+- Was this message altered after it was created?
+- Is this message being replayed from an earlier session?
+- Can the message be verified after it leaves the original transport channel?
+- Can independent implementations produce the same signed bytes?
+
+These questions become more important when agent messages may trigger downstream tool calls, memory updates, delegated tasks, compliance logs, or cross-organization workflows. A secure channel alone protects traffic in transit; it does not create a durable, application-layer proof that a specific agent signed a specific envelope for a specific recipient at a specific time.
+
+AXCP Core addresses this gap with a Secure Baseline profile built around:
+
+- DID-based agent identity.
+- Ed25519 detached signatures.
+- Canonical authentication transcripts.
+- Sequence and nonce replay protection.
+- Security-first profile negotiation.
+- Deterministic cross-SDK compatibility tests.
+
+The design goal is deliberately narrow: AXCP Core is not a full agent framework, not an LLM runtime, not a tool marketplace, and not a commercial governance plane. It is the open protocol substrate for authenticated, replay-resistant message exchange between agents and gateways.
+
+---
+
+## 2. Positioning and Scope
+
+### 2.1 What AXCP Core Is
+
+AXCP Core is an open-source protocol and SDK set for secure agent communication. Its public repository contains:
+
+- The AXCP Core Specification v1.0.
+- The Protobuf schema used by Core envelopes.
+- Go SDK components for authentication, profile negotiation, replay protection, transport helpers, and examples.
+- Python SDK components for identity, signing, verification, replay protection, profile negotiation, QUIC stream framing, and telemetry datagram helpers.
+- TypeScript SDK components for identity, signing, verification, replay protection, profile negotiation, stream framing, and Node TLS transport.
+- A Rust telemetry adapter used for Core experiments, not a canonical full transport SDK.
+- Cross-SDK Secure Baseline vectors and release-readiness checks.
+
+### 2.2 What AXCP Core Is Not
+
+AXCP Core intentionally excludes commercial and deployment-specific features. The following are out of scope for the Core repository and should not be presented as public Core features:
+
+- Commercial license enforcement.
+- Signed Agent Manifest governance.
+- Capability-Bound Execution.
+- ARCANA quantitative autonomy-risk calculus.
+- mTLS certificate lifecycle management.
+- Hardware attestation control planes.
+- PII filtering and redaction pipelines.
+- Compliance reporting workflows.
+- Differential Privacy policy enforcement.
+- Enterprise audit sink and control-center implementations.
+
+These features may exist in commercial/private AXCP tiers, but this paper should treat them as separate product layers. The Core paper should not leak implementation details from those tiers.
+
+AXCP Core authenticates messages. It does not decide whether the business action requested by an authenticated message is authorized. Authorization, approval workflow, policy enforcement, and execution governance belong to higher layers.
+
+### 2.3 Relationship to MCP, A2A, and Tool Protocols
+
+AXCP is complementary to existing agent protocols. MCP-like systems focus on connecting models or agents to tools and external context. A2A-style systems focus on agent interoperability, discovery, and task exchange. AXCP Core focuses on message security: identity, signature verification, replay resistance, and deterministic cross-language verification.
+
+The simplest positioning statement is:
+
+> MCP defines what an agent can call; AXCP verifies who sent the message and whether that message is authentic and fresh.
+
+This framing avoids claiming that AXCP replaces the existing ecosystem. It instead positions AXCP as the security layer that agentic communication will increasingly need as workflows become more autonomous and operationally consequential.
+
+---
+
+## 3. Threat Model
+
+AXCP Core targets the following threat classes:
+
+### 3.1 Message Tampering
+
+An attacker modifies an envelope in transit, in storage, or through a compromised intermediary. AXCP addresses this by signing a canonical authentication transcript over the payload and message bindings. Verification fails if the signed payload, sender, recipient, timestamp, or replay-sensitive fields are altered.
+
+### 3.2 Replay Attacks
+
+An attacker captures a valid message and resends it later to trigger duplicated side effects. AXCP addresses this with sequence or nonce replay protection. Sequence numbers are tracked per peer with a sliding window and TTL. Nonce-based replay protection can be used where monotonic sequencing is not appropriate.
+
+### 3.3 Identity Confusion
+
+An attacker attempts to impersonate an agent by sending a syntactically valid envelope with another sender DID. AXCP requires the verifier to resolve the sender DID, extract an acceptable Ed25519 public key, and verify the detached signature against that key.
+
+### 3.4 Downgrade Attacks
+
+An attacker attempts to force communication into a weaker profile. AXCP Core requires security-first profile negotiation and forbids silent downgrade from `secure-baseline-v1` to deprecated `transport-only-v0`.
+
+### 3.5 Cross-Implementation Drift
+
+Different SDKs may encode the same semantic envelope differently, causing one implementation to sign bytes that another cannot verify. AXCP addresses this through shared deterministic Secure Baseline vectors across Go, Python, and TypeScript.
+
+### 3.6 Explicit Non-Goals
+
+AXCP Core does not claim to solve:
+
+- Prompt injection.
+- Sandboxing or code execution governance.
+- Agent authorization policy.
+- Human approval workflows.
+- Key custody or enterprise PKI lifecycle.
+- Runtime containment.
+- Model behavior alignment.
+
+Those problems require additional layers. AXCP Core provides the message-authentication substrate those layers can build on.
+
+---
+
+## 4. Protocol Overview
+
+### 4.1 Envelope Structure
+
+AXCP messages are represented as Protobuf envelopes. The Core envelope includes:
+
+- Protocol version.
+- Trace identifier.
+- Security profile.
+- One primary payload.
+- Sender DID.
+- Recipient DID.
+- Timestamp.
+- Sequence number.
+- Detached signature.
+- Optional attestation proof field reserved for higher tiers.
+
+The current payload variants include context patches, capability messages, routing policy messages, profile negotiation messages, retry envelopes, telemetry datagrams, and structured errors. Some fields exist in the schema for compatibility or future tier integration, but their policy semantics may be outside Core.
+
+### 4.2 Security Profiles
+
+AXCP Core defines two profiles:
+
+| Profile | Status | Authentication | Replay Protection | Production Use |
+|---|---|---:|---:|---:|
+| `secure-baseline-v1` | Stable | Required | Required | Yes |
+| `transport-only-v0` | Deprecated | Not required | Not required | No |
+
+The Secure Baseline profile is the production default. `transport-only-v0` exists only for compatibility and controlled testing. Implementations must reject deprecated downgrade unless explicitly configured for non-production use.
+
+### 4.3 Profile Negotiation
+
+Profile negotiation is security-first:
+
+1. Validate protocol version.
+2. Validate client-supported profiles.
+3. Select the strongest mutually supported secure profile.
+4. Reject unsupported or unknown profiles.
+5. Reject deprecated fallback unless explicitly allowed.
+6. Resolve the signature algorithm, preferring Ed25519.
+
+This prevents a peer from silently falling back to an unsigned transport-only mode.
+
+---
+
+## 5. Identity and Authentication
+
+### 5.1 DID-Based Identity
+
+AXCP Core uses Decentralized Identifiers as the identity handle for agents and gateways. A DID must follow the standard structure:
+
+```text
+did:<method>:<id>
+```
+
+The current SDKs support `did:key` workflows for local identity generation and verification. Production systems may inject their own DID resolver implementation.
+
+AXCP Core deliberately defines a resolver abstraction rather than a single global registry. This allows deployments to use DID:Web, private registries, internal trust stores, or other DID infrastructure without changing the envelope format.
+
+### 5.2 Ed25519 Signatures
+
+AXCP Core uses Ed25519 signatures for Secure Baseline authentication. A verifier must:
+
+1. Validate the sender DID syntax.
+2. Resolve the DID document.
+3. Confirm that the DID document ID matches the requested DID.
+4. Extract an acceptable Ed25519 verification key.
+5. Verify the detached signature over the AXCP authentication transcript.
+
+Allowed key types include:
+
+- `Ed25519VerificationKey2020`
+- `Ed25519VerificationKey2018`
+
+### 5.3 Authentication Transcript
+
+AXCP signs a canonical transcript with the prefix:
+
+```text
+AXCP-DID-AUTH-v1
+```
+
+The transcript binds:
+
+- Sender DID.
+- Recipient DID.
+- Base64 canonical payload bytes.
+- Timestamp in RFC3339 seconds.
+
+The signed payload excludes detached authentication fields that must not recursively sign themselves:
+
+- `sender_did`
+- `recipient_did`
+- `timestamp_ms`
+- `signature`
+- `attestation_proof`
+
+The replay `sequence` remains covered by the signed payload because replay protection consumes it. Sequence tampering must invalidate the detached signature before replay state is touched.
+
+This point is important for the updated paper. Earlier implementation drift excluded `sequence` in some SDKs. The current repository aligns Go, Python, and TypeScript so that replay-sensitive sequence changes modify the signed payload and fail verification.
+
+---
+
+## 6. Replay Protection
+
+AXCP Core provides replay protection through sequence numbers or nonces.
+
+### 6.1 Sequence Mode
+
+In sequence mode, each incoming message includes a sequence number. The receiver maintains replay state per peer:
+
+1. Expire replay entries older than the TTL.
+2. Reject any sequence already seen within the TTL.
+3. Reject sequences outside the configured sliding window.
+4. Accept new sequences and update the highest-seen sequence when appropriate.
+
+Sequence mode is appropriate for ordered or mostly ordered communication channels where each peer can maintain monotonic counters.
+
+### 6.2 Nonce Mode
+
+Nonce mode is appropriate where strict sequence ordering is not feasible. Each message uses a unique nonce. The receiver stores seen nonces for the TTL and rejects duplicates.
+
+### 6.3 Verification Order
+
+Implementations should verify the detached signature before mutating replay state. This prevents unauthenticated messages from consuming replay slots or polluting the replay cache.
+
+---
+
+## 7. Transport and Encoding
+
+### 7.1 Transport Assumptions
+
+AXCP is designed to run over efficient transport layers such as QUIC/TLS. However, the security model does not depend solely on the transport channel. Secure Baseline adds application-layer authenticity and replay protection above the transport.
+
+The M7 proof path uses the authenticated-chat example ALPN `axcp-auth-chat`. The final paper should describe that value as a proof/example ALPN unless the Core specification explicitly standardizes a universal ALPN registry entry.
+
+### 7.2 Protobuf Encoding
+
+AXCP uses Protobuf envelopes for compact, typed message exchange. The current Core schema is shared across Go, Python, and TypeScript.
+
+The updated paper should avoid unverified claims such as "3x smaller than JSON" unless a current benchmark is regenerated and included with methodology. It is safe to state that Protobuf provides typed binary encoding and can reduce overhead compared with verbose text encodings depending on payload shape.
+
+### 7.3 QUIC DATAGRAM Telemetry
+
+AXCP Core includes telemetry datagram support for low-latency metrics-sized payloads. The current public repository includes QUIC DATAGRAM support paths and tests in the Go netquic surface, plus Python datagram helpers.
+
+This should be framed as telemetry transport support, not as a privacy or compliance feature. Differential Privacy and privacy budget policy belong to commercial tiers and should not be claimed as Core features.
+
+### 7.4 TypeScript Transport Boundary
+
+The TypeScript SDK provides transport-independent framing and Node TLS stream transport. Native QUIC is not bundled because the supported Node runtime path does not expose a stable `node:quic` module. The paper should state this boundary clearly to avoid overclaiming TypeScript QUIC support.
+
+---
+
+## 8. Cross-SDK Interoperability
+
+AXCP Core now has an explicit interoperability contract across Go, Python, and TypeScript.
+
+The shared Secure Baseline vector at:
+
+```text
+testdata/sdk/secure_baseline_vector.json
+```
+
+locks:
+
+- Deterministic Ed25519 seed and `did:key`.
+- Context patch payload.
+- Canonical signing payload bytes.
+- Replay `sequence` inclusion in signed bytes.
+- DID authentication transcript bytes.
+- Detached Ed25519 signature bytes.
+- Full encoded envelope bytes.
+
+Any change to canonical serialization or transcript construction is treated as a compatibility-sensitive protocol change.
+
+### 8.1 Go SDK
+
+The Go SDK is the reference Core implementation. It contains authentication, profile negotiation, replay protection, canonical envelope encoding, gateway-related tests, and transport helpers.
+
+### 8.2 Python SDK
+
+The Python SDK implements the Core security surface:
+
+- Ed25519 identity generation.
+- `did:key` derivation and parsing.
+- Deterministic Protobuf envelope encoding.
+- DID authentication transcript signing and verification.
+- Timestamp validation.
+- Sequence replay protection.
+- Secure Baseline profile negotiation.
+- Async QUIC stream transport with AXCP envelope framing.
+- QUIC DATAGRAM helpers for telemetry-sized payloads.
+
+### 8.3 TypeScript SDK
+
+The TypeScript SDK implements the Core security surface:
+
+- Ed25519 identity generation.
+- `did:key` derivation.
+- DID parsing and resolver interfaces.
+- Deterministic AXCP Protobuf envelope encoding.
+- DID authentication transcript signing and verification.
+- Timestamp validation.
+- Sequence and nonce replay protection.
+- Secure Baseline profile negotiation.
+- Stream framing and Node TLS transport.
+
+### 8.4 Rust Boundary
+
+Rust is currently present as an experimental telemetry adapter for AXCP Core experiments. It should not be described as a production-equivalent canonical transport SDK unless that scope is implemented and tested later.
+
+---
+
+## 9. Security Properties
+
+AXCP Core provides the following properties when `secure-baseline-v1` is correctly implemented and configured:
+
+### 9.1 Message Authenticity
+
+A valid AXCP message is signed by the private key corresponding to the sender DID. Verification requires resolving the DID document and validating an Ed25519 signature.
+
+### 9.2 Message Integrity
+
+Changes to the canonical signed payload invalidate the signature. This includes changes to payload content and replay sequence.
+
+### 9.3 Recipient Binding
+
+The recipient DID is included in the authentication transcript. A signature created for one intended recipient cannot be transparently reused as a valid message for another recipient without detection.
+
+### 9.4 Replay Resistance
+
+Sequence or nonce state prevents re-accepting the same signed message within the configured replay window.
+
+### 9.5 Auditability
+
+Because signatures are at the message layer, an AXCP message can remain verifiable outside the original TLS session. This enables later inspection of message provenance. Core provides the cryptographic substrate; durable audit storage and compliance workflows belong to higher tiers.
+
+### 9.6 Downgrade Resistance
+
+Secure Baseline negotiation prevents silent fallback into unsigned transport-only mode.
+
+---
+
+## 10. Implementation and Verification
+
+### 10.1 Repository Structure
+
+The current public repository contains:
+
+```text
+spec/axcp-v1.0.md
+proto/axcp.proto
+sdk/go/
+sdk/python/
+sdk/typescript/
+sdk/rust/
+edge/gateway/
+edge/rpi-agent/
+testdata/sdk/secure_baseline_vector.json
+docs/
+```
+
+### 10.2 Continuous Integration
+
+The current CI checks include:
+
+- Go tests, including race-enabled paths.
+- Python tests and SDK release-readiness checks.
+- TypeScript typecheck, tests, and package dry-run.
+- Rust stable/beta/nightly checks.
+- Rust formatting, clippy, docs, and unused dependency checks.
+- Gateway telemetry checks.
+- RPi agent checks.
+- Example build checks.
+- CLA/license status.
+
+The final paper may state that CI covers these categories, but should avoid claiming a fixed total test count unless generated automatically during final release.
+
+### 10.3 Local Release Gates
+
+The release-readiness document defines local gates:
+
+```bash
+python scripts/verify_sdk_release_readiness.py
+PYTHONPATH=$PWD python -m pytest -q scripts gateway sdk/python/tests
+(cd sdk/typescript && npm ci && npm test && npm run typecheck && npm pack --dry-run)
+(cd sdk/go && go test ./...)
+(cd edge/gateway && go test ./...)
+(cd edge/rpi-agent && go test ./...)
+(cd sdk/rust && cargo fmt --all --check && cargo test --quiet)
+git diff --check
+```
+
+These commands are useful as the final paper's reproducibility appendix.
+
+---
+
+## 11. Comparison With Existing Approaches
+
+This section needs final citations from primary sources before publication. Use only official MCP, A2A, protocol documentation, or academic/security references.
+
+### 11.1 Tool Protocols
+
+Tool protocols standardize how models or agents call tools and exchange context. They are valuable for developer adoption and ecosystem interoperability. Their primary concern is not necessarily message-level attribution, verifiability, or replay protection between autonomous agents.
+
+AXCP Core can wrap or complement such systems by adding message-level DID authentication and replay protection.
+
+### 11.2 Transport Security Alone
+
+TLS protects a connection. AXCP Secure Baseline protects the message. The difference matters when messages are stored, forwarded, audited, replayed, or routed through intermediaries.
+
+### 11.3 OAuth and Centralized Identity
+
+OAuth-based systems are familiar and operationally mature, but they generally depend on an identity provider and token lifecycle. AXCP's DID model allows agent identity to be represented directly by cryptographic keys and resolver-backed DID documents. This does not eliminate the need for governance; it separates the Core identity primitive from any single centralized provider.
+
+### 11.4 gRPC/HTTP-Based Agent Communication
+
+gRPC and HTTP-based protocols provide mature transport and tooling. AXCP's contribution is not merely a transport choice, but the application-layer security envelope: signed messages, deterministic transcript construction, and replay protection.
+
+---
+
+## 12. Limitations
+
+AXCP Core has important limitations:
+
+1. Core does not decide whether an agent is authorized to perform a business action.
+2. Core does not prove that an agent's internal reasoning is safe.
+3. Core does not sandbox code execution.
+4. Core does not provide enterprise key custody, policy management, or compliance reporting.
+5. Core does not solve prompt injection.
+6. Core does not publish a universal DID registry.
+7. Core interoperability depends on strict canonicalization; implementers must use SDK-provided helpers rather than hand-built transcripts.
+
+These limitations are intentional. AXCP Core should remain small, auditable, and interoperable.
+
+---
+
+## 13. Future Work
+
+Future work should be separated into public Core evolution and private/commercial product evolution.
+
+### 13.1 Public Core Roadmap
+
+Possible public Core roadmap items:
+
+- Additional formal interoperability vectors.
+- More conformance tests.
+- Expanded examples for authenticated agent-to-agent exchange.
+- Public benchmark methodology regenerated from current SDKs.
+- Additional DID method examples.
+- Improved transport adapters where runtime support is stable.
+
+### 13.2 Commercial Tier Roadmap
+
+Commercial tier capabilities should remain high-level in this paper:
+
+- mTLS management.
+- Hardware attestation.
+- PII controls.
+- Configurable privacy controls.
+- Compliance reporting.
+- Signed agent identity governance.
+- Execution governance.
+- Enterprise audit and control-plane features.
+
+Do not include implementation mechanics in the public paper.
+
+### 13.3 Research Roadmap
+
+ARCANA and related autonomy-risk research can be mentioned only as future research if needed, without formulas or architecture details in this Core paper. The safer approach is to keep ARCANA out of this paper entirely and publish it as a separate research artifact once ready.
+
+---
+
+## 14. Conclusion
+
+AXCP Core provides a focused security layer for autonomous agent communication. Its Secure Baseline profile binds agent identity, recipient identity, canonical payload bytes, timestamp, and replay-sensitive sequence material into a verifiable Ed25519 authentication transcript.
+
+The updated repository state strengthens the original AXCP paper in three ways. First, AXCP Core now has a clearer public boundary: the Apache 2.0 repository contains the Core protocol and SDKs, while Advanced and Enterprise capabilities remain separate commercial tiers. Second, the SDK surface is broader and more practical: Go, Python, and TypeScript now share the Secure Baseline security model. Third, cross-SDK compatibility is tested with a deterministic vector that locks the exact bytes used for signing, transcript construction, signature verification, and envelope encoding.
+
+AXCP should not be presented as a replacement for the agent ecosystem. It is better positioned as the message-security layer that can make agent-to-agent and agent-to-gateway communication verifiable, replay-resistant, and auditable as autonomy increases.
+
+---
+
+## Suggested LaTeX Structure
+
+```text
+\title{AXCP Core: Message-Level Identity, Authentication, and Replay Protection for Autonomous Agent Communication}
+\author{Julio Elizondo Rodriguez \\ TradePhantom LLC}
+\date{2026}
+
+\begin{abstract}
+...
+\end{abstract}
+
+\section{Introduction}
+\section{Positioning and Scope}
+\section{Threat Model}
+\section{Protocol Overview}
+\section{Identity and Authentication}
+\section{Replay Protection}
+\section{Transport and Encoding}
+\section{Cross-SDK Interoperability}
+\section{Security Properties}
+\section{Implementation and Verification}
+\section{Comparison With Existing Approaches}
+\section{Limitations}
+\section{Future Work}
+\section{Conclusion}
+\appendix
+\section{Secure Baseline Test Vector}
+\section{Release Verification Commands}
+```
+
+---
+
+## Claims Requiring Final Verification Before Publication
+
+Do not publish the final paper until these are checked:
+
+1. Current CI badge is green on `main`.
+2. Current repository has no open required-check PRs.
+3. The shared Secure Baseline vector passes in Go, Python, and TypeScript.
+4. Any performance table is regenerated from current code.
+5. Any test count is generated from current CI or scripts, not copied from the February paper.
+6. Zenodo metadata lists current implementation languages: Go, Python, TypeScript, and Rust with Rust properly qualified.
+7. Commercial-tier feature wording matches the website and private product boundary.
+8. No private Enterprise implementation details are included.
+9. The DOI versioning strategy is chosen: new Zenodo version under the same concept DOI or separate record.
+10. The final LaTeX bibliography uses primary sources only for MCP, A2A, DID, Ed25519, QUIC/TLS, and Protobuf claims.
+
+---
+
+## Source Anchors
+
+Use these repository files as anchors during final editing:
+
+- `spec/axcp-v1.0.md`
+- `proto/axcp.proto`
+- `docs/authentication.md`
+- `docs/gateway-setup.md`
+- `docs/sdk-release-readiness.md`
+- `sdk/go/`
+- `sdk/python/README.md`
+- `sdk/typescript/README.md`
+- `sdk/rust/README.md`
+- `testdata/sdk/secure_baseline_vector.json`
+- `README.md`
+
+Use the existing Zenodo v1.0 record as prior-publication context:
+
+- `https://zenodo.org/records/18475648`

--- a/examples/go/authenticated_chat/main.go
+++ b/examples/go/authenticated_chat/main.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/tradephantomllc/axcp-spec/sdk/go/auth"
+	"github.com/tradephantomllc/axcp-spec/sdk/go/axcp"
 	pb "github.com/tradephantomllc/axcp-spec/sdk/go/axcp/pb"
 	"github.com/tradephantomllc/axcp-spec/sdk/go/negotiate"
 )
@@ -196,18 +197,12 @@ func runServer(tlsConf *tls.Config) {
 	}
 	clientPubKey := doc.PublicKeys[0].PublicKeyBytes
 
-	// Rebuild transcript for verification
-	// Extract payload (envelope without auth fields)
-	envCopy := &pb.AxcpEnvelope{
-		Version: env.Version,
-		TraceId: env.TraceId,
-		Profile: env.Profile,
+	// Rebuild transcript for verification. The canonical signing payload
+	// excludes detached auth fields but retains replay sequence.
+	payloadBytes, err := axcp.SigningPayloadFromProto(&env)
+	if err != nil {
+		log.Fatalf("Failed to build client signing payload: %v", err)
 	}
-	if env.GetContextPatch() != nil {
-		envCopy.Payload = &pb.AxcpEnvelope_ContextPatch{ContextPatch: env.GetContextPatch()}
-	}
-	payloadBytes, _ := proto.Marshal(envCopy)
-
 	timestamp := time.UnixMilli(int64(env.TimestampMs))
 	transcript := auth.BuildDIDAuthTranscript(clientDID, env.RecipientDid, payloadBytes, timestamp)
 
@@ -240,11 +235,14 @@ func runServer(tlsConf *tls.Config) {
 		Payload: &pb.AxcpEnvelope_ContextPatch{ContextPatch: respPatch},
 	}
 
-	// Sign response
-	respPayloadBytes, _ := proto.Marshal(respEnv)
+	// Sign response. The session allocates sequence first, then the payload
+	// builder inserts that sequence into the canonical signing payload.
 	sigOutput, err := session.SignEnvelope(context.Background(), auth.SignatureInput{
-		Payload:      respPayloadBytes,
 		RecipientDID: clientDID,
+		PayloadForSequence: func(sequence uint64) ([]byte, error) {
+			respEnv.Sequence = sequence
+			return axcp.SigningPayloadFromProto(respEnv)
+		},
 	})
 	if err != nil {
 		log.Fatalf("Failed to sign response: %v", err)
@@ -335,10 +333,13 @@ func runClient(tlsConf *tls.Config) {
 		Payload: &pb.AxcpEnvelope_ContextPatch{ContextPatch: reqPatch},
 	}
 
-	// Sign the envelope
-	payloadBytes, _ := proto.Marshal(reqEnv)
+	// Sign the envelope. The sequence is part of the signed payload, so it must
+	// be assigned before canonical signing payload bytes are built.
 	sigOutput, err := session.SignEnvelope(context.Background(), auth.SignatureInput{
-		Payload: payloadBytes,
+		PayloadForSequence: func(sequence uint64) ([]byte, error) {
+			reqEnv.Sequence = sequence
+			return axcp.SigningPayloadFromProto(reqEnv)
+		},
 	})
 	if err != nil {
 		log.Fatalf("Failed to sign envelope: %v", err)
@@ -398,17 +399,12 @@ func runClient(tlsConf *tls.Config) {
 	}
 	serverPubKey := doc.PublicKeys[0].PublicKeyBytes
 
-	// Rebuild transcript
-	respCopy := &pb.AxcpEnvelope{
-		Version: respEnv.Version,
-		TraceId: respEnv.TraceId,
-		Profile: respEnv.Profile,
+	// Rebuild transcript. The canonical signing payload excludes detached auth
+	// fields but retains replay sequence.
+	respPayloadBytes, err := axcp.SigningPayloadFromProto(&respEnv)
+	if err != nil {
+		log.Fatalf("Failed to build response signing payload: %v", err)
 	}
-	if respEnv.GetContextPatch() != nil {
-		respCopy.Payload = &pb.AxcpEnvelope_ContextPatch{ContextPatch: respEnv.GetContextPatch()}
-	}
-	respPayloadBytes, _ := proto.Marshal(respCopy)
-
 	respTimestamp := time.UnixMilli(int64(respEnv.TimestampMs))
 	respTranscript := auth.BuildDIDAuthTranscript(respEnv.SenderDid, respEnv.RecipientDid, respPayloadBytes, respTimestamp)
 
@@ -476,9 +472,11 @@ func runReplayTest(tlsConf *tls.Config) {
 		Payload: &pb.AxcpEnvelope_ContextPatch{ContextPatch: reqPatch},
 	}
 
-	payloadBytes, _ := proto.Marshal(reqEnv)
 	sigOutput, _ := session.SignEnvelope(context.Background(), auth.SignatureInput{
-		Payload: payloadBytes,
+		PayloadForSequence: func(sequence uint64) ([]byte, error) {
+			reqEnv.Sequence = sequence
+			return axcp.SigningPayloadFromProto(reqEnv)
+		},
 	})
 
 	reqEnv.SenderDid = sigOutput.SenderDID

--- a/sdk/go/auth/did.go
+++ b/sdk/go/auth/did.go
@@ -182,26 +182,27 @@ const (
 )
 
 // BuildDIDAuthTranscript creates a canonical payload for DID authentication signing.
-// The transcript binds the signature to specific parties, challenge, and timestamp.
+// The transcript binds the signature to specific parties, canonical signing
+// payload bytes, and timestamp.
 //
 // Format:
 //
 //	AXCP-DID-AUTH-v1\n
-//	<clientDID>\n
-//	<serverDID>\n
-//	<base64(challenge)>\n
+//	<senderDID>\n
+//	<recipientDID>\n
+//	<base64(canonicalSigningPayload)>\n
 //	<timestampRFC3339>
 //
 // This deterministic format ensures both parties compute identical transcripts.
-func BuildDIDAuthTranscript(clientDID, serverDID string, challenge []byte, ts time.Time) []byte {
-	challengeB64 := base64.StdEncoding.EncodeToString(challenge)
+func BuildDIDAuthTranscript(senderDID, recipientDID string, canonicalSigningPayload []byte, ts time.Time) []byte {
+	payloadB64 := base64.StdEncoding.EncodeToString(canonicalSigningPayload)
 	timestampStr := ts.UTC().Format(time.RFC3339)
 
 	transcript := strings.Join([]string{
 		DIDAuthTranscriptVersion,
-		clientDID,
-		serverDID,
-		challengeB64,
+		senderDID,
+		recipientDID,
+		payloadB64,
 		timestampStr,
 	}, "\n")
 

--- a/sdk/go/auth/did_test.go
+++ b/sdk/go/auth/did_test.go
@@ -299,11 +299,11 @@ func TestResolveEd25519PublicKey_Accepts2018KeyType(t *testing.T) {
 func TestBuildDIDAuthTranscript_Deterministic(t *testing.T) {
 	clientDID := "did:example:client"
 	serverDID := "did:example:server"
-	challenge := []byte("random-challenge-bytes")
+	signingPayload := []byte("canonical-signing-payload")
 	ts := time.Date(2026, 1, 27, 12, 0, 0, 0, time.UTC)
 
-	transcript1 := BuildDIDAuthTranscript(clientDID, serverDID, challenge, ts)
-	transcript2 := BuildDIDAuthTranscript(clientDID, serverDID, challenge, ts)
+	transcript1 := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload, ts)
+	transcript2 := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload, ts)
 
 	if string(transcript1) != string(transcript2) {
 		t.Error("transcripts should be deterministic")
@@ -313,10 +313,10 @@ func TestBuildDIDAuthTranscript_Deterministic(t *testing.T) {
 func TestBuildDIDAuthTranscript_Format(t *testing.T) {
 	clientDID := "did:example:client"
 	serverDID := "did:example:server"
-	challenge := []byte("test")
+	signingPayload := []byte("test")
 	ts := time.Date(2026, 1, 27, 12, 0, 0, 0, time.UTC)
 
-	transcript := BuildDIDAuthTranscript(clientDID, serverDID, challenge, ts)
+	transcript := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload, ts)
 	transcriptStr := string(transcript)
 
 	// Expected format:
@@ -330,10 +330,10 @@ func TestBuildDIDAuthTranscript_Format(t *testing.T) {
 
 func TestBuildDIDAuthTranscript_DifferentInputsProduceDifferentTranscripts(t *testing.T) {
 	ts := time.Now()
-	challenge := []byte("challenge")
+	signingPayload := []byte("canonical-signing-payload")
 
-	t1 := BuildDIDAuthTranscript("did:example:a", "did:example:b", challenge, ts)
-	t2 := BuildDIDAuthTranscript("did:example:c", "did:example:b", challenge, ts) // Different client
+	t1 := BuildDIDAuthTranscript("did:example:a", "did:example:b", signingPayload, ts)
+	t2 := BuildDIDAuthTranscript("did:example:c", "did:example:b", signingPayload, ts) // Different client
 
 	if string(t1) == string(t2) {
 		t.Error("different clients should produce different transcripts")
@@ -368,10 +368,10 @@ func TestVerifyDIDAuthSignature_Success(t *testing.T) {
 	// Build transcript
 	clientDID := "did:example:alice"
 	serverDID := "did:example:server"
-	challenge := []byte("server-challenge-12345")
+	signingPayload := []byte("server-payload-12345")
 	ts := time.Now()
 
-	transcript := BuildDIDAuthTranscript(clientDID, serverDID, challenge, ts)
+	transcript := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload, ts)
 
 	// Sign transcript with alice's private key
 	signature, err := SignEd25519(privateKey, transcript)
@@ -500,8 +500,8 @@ func TestVerifyDIDAuthSignature_WrongSigner(t *testing.T) {
 	}
 }
 
-func TestVerifyDIDAuthSignature_ChallengeBinding(t *testing.T) {
-	// This test verifies that the signature is bound to the specific challenge
+func TestVerifyDIDAuthSignature_PayloadBinding(t *testing.T) {
+	// This test verifies that the signature is bound to the specific signing payload
 	publicKey, privateKey, _ := GenerateEd25519Keypair()
 
 	resolver := &FakeResolver{
@@ -517,26 +517,26 @@ func TestVerifyDIDAuthSignature_ChallengeBinding(t *testing.T) {
 
 	clientDID := "did:example:alice"
 	serverDID := "did:example:server"
-	challenge1 := []byte("challenge-1")
-	challenge2 := []byte("challenge-2")
+	signingPayload1 := []byte("payload-1")
+	signingPayload2 := []byte("payload-2")
 	ts := time.Now()
 
-	// Sign with challenge1
-	transcript1 := BuildDIDAuthTranscript(clientDID, serverDID, challenge1, ts)
+	// Sign with signingPayload1
+	transcript1 := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload1, ts)
 	signature, _ := SignEd25519(privateKey, transcript1)
 
-	// Verify with challenge1 - should succeed
+	// Verify with signingPayload1 - should succeed
 	ctx := context.Background()
 	err := VerifyDIDAuthSignature(ctx, resolver, clientDID, transcript1, signature)
 	if err != nil {
-		t.Errorf("verification with correct challenge failed: %v", err)
+		t.Errorf("verification with correct signing payload failed: %v", err)
 	}
 
-	// Verify with challenge2 - should fail (different transcript)
-	transcript2 := BuildDIDAuthTranscript(clientDID, serverDID, challenge2, ts)
+	// Verify with signingPayload2 - should fail (different transcript)
+	transcript2 := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload2, ts)
 	err = VerifyDIDAuthSignature(ctx, resolver, clientDID, transcript2, signature)
 	if err != ErrVerificationFailed {
-		t.Errorf("expected ErrVerificationFailed for wrong challenge, got %v", err)
+		t.Errorf("expected ErrVerificationFailed for wrong signing payload, got %v", err)
 	}
 }
 
@@ -601,12 +601,12 @@ func TestDIDAuth_FullFlow(t *testing.T) {
 	clientDID := "did:example:client"
 	serverDID := "did:example:server"
 
-	// Step 1: Server generates challenge
-	challenge := []byte("server-random-challenge-xyz")
+	// Step 1: Build canonical signing payload bytes
+	signingPayload := []byte("server-canonical-payload-xyz")
 	ts := time.Now()
 
 	// Step 2: Client builds and signs transcript
-	clientTranscript := BuildDIDAuthTranscript(clientDID, serverDID, challenge, ts)
+	clientTranscript := BuildDIDAuthTranscript(clientDID, serverDID, signingPayload, ts)
 	clientSignature, err := SignEd25519(clientPrivate, clientTranscript)
 	if err != nil {
 		t.Fatalf("client signing failed: %v", err)
@@ -619,7 +619,7 @@ func TestDIDAuth_FullFlow(t *testing.T) {
 	}
 
 	// Step 4: Server responds with its own signature (mutual auth)
-	serverTranscript := BuildDIDAuthTranscript(serverDID, clientDID, challenge, ts)
+	serverTranscript := BuildDIDAuthTranscript(serverDID, clientDID, signingPayload, ts)
 	serverSignature, err := SignEd25519(serverPrivate, serverTranscript)
 	if err != nil {
 		t.Fatalf("server signing failed: %v", err)
@@ -639,12 +639,12 @@ func TestDIDAuth_FullFlow(t *testing.T) {
 func BenchmarkBuildDIDAuthTranscript(b *testing.B) {
 	clientDID := "did:example:client"
 	serverDID := "did:example:server"
-	challenge := make([]byte, 32)
+	signingPayload := make([]byte, 32)
 	ts := time.Now()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = BuildDIDAuthTranscript(clientDID, serverDID, challenge, ts)
+		_ = BuildDIDAuthTranscript(clientDID, serverDID, signingPayload, ts)
 	}
 }
 
@@ -662,7 +662,7 @@ func BenchmarkVerifyDIDAuthSignature(b *testing.B) {
 		},
 	}
 
-	transcript := BuildDIDAuthTranscript("did:example:alice", "did:example:server", []byte("challenge"), time.Now())
+	transcript := BuildDIDAuthTranscript("did:example:alice", "did:example:server", []byte("signing payload"), time.Now())
 	signature, _ := SignEd25519(privateKey, transcript)
 
 	ctx := context.Background()

--- a/sdk/go/auth/session.go
+++ b/sdk/go/auth/session.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,8 +32,8 @@ type Session struct {
 	mu sync.RWMutex
 
 	// Identity
-	localDID  string
-	remoteDID string
+	localDID   string
+	remoteDID  string
 	privateKey ed25519.PrivateKey
 
 	// Negotiation state
@@ -126,8 +127,17 @@ func (s *Session) CurrentSequence() uint64 {
 
 // SignatureInput contains the data needed to create a signed envelope.
 type SignatureInput struct {
-	// Payload is the serialized envelope payload (without auth fields)
+	// Payload is a prebuilt canonical signing payload.
+	//
+	// For AXCP Secure Baseline envelope signing, the payload must include the
+	// final replay sequence. Prefer PayloadForSequence when the session owns
+	// sequence allocation.
 	Payload []byte
+
+	// PayloadForSequence builds the canonical signing payload after the session
+	// allocates the final replay sequence. This is the preferred path for
+	// envelope signing because sequence must be covered by the signature.
+	PayloadForSequence func(sequence uint64) ([]byte, error)
 
 	// RecipientDID overrides the remote DID for directed messages (optional)
 	RecipientDID string
@@ -178,8 +188,17 @@ func (s *Session) SignEnvelope(ctx context.Context, input SignatureInput) (*Sign
 	timestampMs := uint64(now.UnixMilli())
 	sequence := s.NextSequence()
 
+	signingPayload := input.Payload
+	if input.PayloadForSequence != nil {
+		var err error
+		signingPayload, err = input.PayloadForSequence(sequence)
+		if err != nil {
+			return nil, fmt.Errorf("auth: build signing payload: %w", err)
+		}
+	}
+
 	// Build transcript for signing
-	transcript := BuildDIDAuthTranscript(localDID, recipientDID, input.Payload, now)
+	transcript := BuildDIDAuthTranscript(localDID, recipientDID, signingPayload, now)
 
 	// Sign the transcript
 	signature := ed25519.Sign(privateKey, transcript)

--- a/sdk/go/auth/session_test.go
+++ b/sdk/go/auth/session_test.go
@@ -91,6 +91,45 @@ func TestSession_SequenceCounter(t *testing.T) {
 	}
 }
 
+func TestSession_SignEnvelopePayloadForSequence(t *testing.T) {
+	did, pubKey, privKey, err := GenerateTestIdentity()
+	if err != nil {
+		t.Fatalf("GenerateTestIdentity failed: %v", err)
+	}
+
+	remoteDID := "did:key:remote"
+	session := NewSession(SessionConfig{
+		LocalDID:   did,
+		PrivateKey: privKey,
+	})
+	session.SetNegotiated("secure-baseline-v1", remoteDID)
+
+	output, err := session.SignEnvelope(context.Background(), SignatureInput{
+		PayloadForSequence: func(sequence uint64) ([]byte, error) {
+			return []byte{byte(sequence), 'p', 'a', 'y', 'l', 'o', 'a', 'd'}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("SignEnvelope failed: %v", err)
+	}
+
+	if output.Sequence != 1 {
+		t.Fatalf("Sequence = %d, want 1", output.Sequence)
+	}
+
+	wantPayload := []byte{byte(output.Sequence), 'p', 'a', 'y', 'l', 'o', 'a', 'd'}
+	transcript := BuildDIDAuthTranscript(did, remoteDID, wantPayload, time.UnixMilli(int64(output.TimestampMs)))
+	if !VerifyEd25519(pubKey, transcript, output.Signature) {
+		t.Fatal("signature did not cover sequence-aware signing payload")
+	}
+
+	wrongPayload := []byte{byte(output.Sequence + 1), 'p', 'a', 'y', 'l', 'o', 'a', 'd'}
+	wrongTranscript := BuildDIDAuthTranscript(did, remoteDID, wrongPayload, time.UnixMilli(int64(output.TimestampMs)))
+	if VerifyEd25519(pubKey, wrongTranscript, output.Signature) {
+		t.Fatal("signature verified with payload for a different sequence")
+	}
+}
+
 func TestSession_RecipientOverride(t *testing.T) {
 	did, _, privKey, _ := GenerateTestIdentity()
 	session := NewSession(SessionConfig{

--- a/spec/axcp-v1.0.md
+++ b/spec/axcp-v1.0.md
@@ -260,17 +260,32 @@ The authentication transcript MUST be constructed exactly as follows:
 **Format:**
 ```
 AXCP-DID-AUTH-v1\n
-<clientDID>\n
-<serverDID>\n
-<base64(challenge)>\n
+<senderDID>\n
+<recipientDID>\n
+<base64(canonicalSigningPayload)>\n
 <timestampRFC3339>
 ```
 
 Where:
 - `\n` is the newline character (0x0A)
 - Fields are joined with `\n` (no trailing newline)
-- `<base64(challenge)>` uses standard Base64 encoding (RFC 4648)
+- `<senderDID>` is the DID of the signing agent or gateway
+- `<recipientDID>` is the intended recipient DID
+- `<base64(canonicalSigningPayload)>` uses standard Base64 encoding (RFC 4648)
 - `<timestampRFC3339>` is UTC time formatted as RFC3339 (e.g., `2026-01-29T12:00:00Z`)
+
+The canonical signing payload is the deterministic Protobuf encoding of the
+AXCP envelope after clearing detached authentication fields:
+
+- `sender_did`
+- `recipient_did`
+- `timestamp_ms`
+- `signature`
+- `attestation_proof`
+
+The replay `sequence` field MUST remain in the canonical signing payload.
+Changing `sequence` MUST change the signing payload and MUST invalidate the
+detached signature before replay state is mutated.
 
 **Example transcript:**
 ```
@@ -437,19 +452,19 @@ Server (AllowDeprecated=false):
 ### A.2 Transcript Composition Example
 
 Given:
-- Client DID: `did:key:z6MkClient123`
-- Server DID: `did:key:z6MkServer456`
-- Challenge: `[0x48, 0x65, 0x6c, 0x6c, 0x6f]` (ASCII "Hello")
+- Sender DID: `did:key:z6MkClient123`
+- Recipient DID: `did:key:z6MkServer456`
+- Canonical signing payload bytes: `[0x08, 0x01, 0x12, 0x09, 0x74, 0x72, 0x61, 0x63, 0x65, 0x2d, 0x31, 0x32, 0x33, 0x18, 0x01, 0xb0, 0x01, 0x2a]`
 - Timestamp: 2026-01-29T15:30:00Z
 
-Challenge Base64: `SGVsbG8=`
+Canonical signing payload Base64: `CAESCXRyYWNlLTEyMxgBsAEq`
 
 Transcript bytes (UTF-8):
 ```
 AXCP-DID-AUTH-v1
 did:key:z6MkClient123
 did:key:z6MkServer456
-SGVsbG8=
+CAESCXRyYWNlLTEyMxgBsAEq
 2026-01-29T15:30:00Z
 ```
 


### PR DESCRIPTION
## Summary

- Aligns the authoritative Core spec and authentication guide with the current Secure Baseline signing model: sender DID, recipient DID, canonical signing payload bytes, timestamp, and replay sequence coverage.
- Adds a sequence-aware Go session signing path so callers can build the canonical payload after the session allocates the replay sequence.
- Updates the authenticated chat example to sign and verify with the same canonical payload helper used by SDK validation.
- Adds the AXCP Core v1.1 paper source draft for LaTeX/editorial handoff, including version-sync and publication guardrails.

## Root Cause

The SDKs and Secure Baseline vector had moved to the canonical signing payload model where `sequence` remains covered by the signature, but `spec/axcp-v1.0.md` and `docs/authentication.md` still described the older challenge-style transcript. That created a source-of-truth mismatch before the updated paper could be finalized.

## Validation

- `go test ./...`
- `(cd sdk/go && go test ./... && go vet ./...)`
- `go test ./examples/go/authenticated_chat && go vet ./examples/go/authenticated_chat`
- `(cd sdk/typescript && npm test -- --runInBand)`
- `uv run --python /Users/tradephantom/.local/bin/python3.13 --with pytest --with aioquic --with protobuf --with PyNaCl --with-editable sdk/python pytest -q sdk/python/tests`
- `git diff --check`
- residual legacy wording scan for `base64(challenge)`, old challenge labels, and `non-repudiation`
