### PR TITLE
[codex] Fix edge auth replay ordering

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,14 +4,14 @@ This guide helps you set up and run AXCP Core with Secure Baseline authenticatio
 
 ## Prerequisites
 
-- **Go 1.23+** (CI uses Go 1.23.4)
+- **Go 1.25.6+** (CI uses Go 1.25.6)
 - Git
 
 Verify your Go installation:
 
 ```bash
 go version
-# Expected: go version go1.23.x ...
+# Expected: go version go1.25.6 or later
 ```
 
 ## Installation
@@ -31,7 +31,7 @@ Run tests to verify everything is working:
 go test ./sdk/go/...
 ```
 
-All tests should pass. If you see import errors, ensure you're using Go 1.23+.
+All tests should pass. If you see import errors, ensure you're using Go 1.25.6+.
 
 ## Python SDK Core
 
@@ -172,9 +172,9 @@ Bidirectional authenticated exchange completed!
 
 Install Go from https://go.dev/dl/ and ensure it's in your PATH.
 
-### "go version" shows < 1.23
+### "go version" shows < 1.25.6
 
-Update Go to version 1.23 or later. AXCP Core requires Go 1.23+.
+Update Go to version 1.25.6 or later. AXCP Core requires Go 1.25.6+.
 
 ### Import errors when running tests
 

--- a/docs/paper/AXCP_Core_vNext_Paper_Draft.md
+++ b/docs/paper/AXCP_Core_vNext_Paper_Draft.md
@@ -3,7 +3,7 @@
 **Working title:** AXCP Core: Message-Level Identity, Authentication, and Replay Protection for Autonomous Agent Communication
 **Draft status:** Source draft for editorial review and LaTeX conversion
 **Target venue/artifact:** Updated Zenodo preprint replacing or versioning the February 2026 AXCP v1.0 paper
-**Prepared from repository state:** `tradephantomllc/axcp-spec` `main`, after PRs #254 and #255
+**Prepared from repository state:** `tradephantomllc/axcp-spec` `main`, after transcript-alignment PR #256 and replay-order verification updates
 **Date:** 2026-07-05
 **Scope:** AXCP Core only, Apache 2.0 open-source repository
 
@@ -39,7 +39,7 @@ Use this as the source of truth for the final manuscript metadata:
 | Paper version | AXCP Core Paper v1.1 / 2026 revision |
 | Protocol specification | AXCP Core Specification v1.0, Secure Baseline |
 | Repository | `tradephantomllc/axcp-spec` |
-| Repository state | `main` after transcript/spec/authentication alignment |
+| Repository state | `main` after transcript/spec/authentication alignment and replay-order verification |
 | Publication target | Zenodo updated version under the existing concept DOI |
 | Core boundary | Apache 2.0 public repository; no Advanced/Enterprise code |
 | SDKs covered | Go, Python, TypeScript |
@@ -603,7 +603,8 @@ Do not publish the final paper until these are checked:
 7. Commercial-tier feature wording matches the website and private product boundary.
 8. No private Enterprise implementation details are included.
 9. The DOI versioning strategy is chosen: new Zenodo version under the same concept DOI or separate record.
-10. The final LaTeX bibliography uses primary sources only for MCP, A2A, DID, Ed25519, QUIC/TLS, and Protobuf claims.
+10. A new protocol proof pack is generated from the final paper-ready commit; do not reuse the historical M7 proof pack as final evidence.
+11. The final LaTeX bibliography uses primary sources only for MCP, A2A, DID, Ed25519, QUIC/TLS, and Protobuf claims.
 
 ---
 

--- a/edge/gateway/internal/auth.go
+++ b/edge/gateway/internal/auth.go
@@ -101,7 +101,7 @@ type EnvelopeAuth struct {
 	TimestampMs  uint64
 	Sequence     uint64
 	Signature    []byte
-	PayloadBytes []byte // The serialized payload for signature verification
+	PayloadBytes []byte // Canonical signing payload bytes for signature verification
 }
 
 // AuthResult contains the result of authentication verification.
@@ -132,9 +132,9 @@ const (
 // For Secure Baseline profile:
 //  1. Validates sender_did is present and parseable
 //  2. Validates timestamp is within acceptable window
-//  3. Checks replay protection (sequence number)
-//  4. Resolves sender's public key via DID resolver
-//  5. Verifies Ed25519 signature over the auth transcript
+//  3. Resolves sender's public key via DID resolver
+//  4. Verifies Ed25519 signature over the auth transcript
+//  5. Checks replay protection (sequence number)
 //
 // Returns AuthResult with Authenticated=true on success, or with Error and ErrorCode on failure.
 func (ea *EnvelopeAuthenticator) VerifyEnvelope(ctx context.Context, profile negotiate.Profile, envAuth EnvelopeAuth) AuthResult {
@@ -174,18 +174,6 @@ func (ea *EnvelopeAuthenticator) VerifyEnvelope(ctx context.Context, profile neg
 		}
 	}
 
-	// Check replay protection
-	if err := ea.replay.CheckAndMark(envAuth.SenderDID, envAuth.Sequence); err != nil {
-		code := ErrorCodeAuthReplayDetected
-		if errors.Is(err, auth.ErrTooOld) {
-			code = ErrorCodeAuthTimestampExpired // Sequence too old is similar to timestamp expired
-		}
-		return AuthResult{
-			Error:     err,
-			ErrorCode: uint32(code),
-		}
-	}
-
 	// Build auth transcript for signature verification
 	timestamp := time.UnixMilli(int64(envAuth.TimestampMs))
 	recipientDID := envAuth.RecipientDID
@@ -206,6 +194,19 @@ func (ea *EnvelopeAuthenticator) VerifyEnvelope(ctx context.Context, profile neg
 		code := ErrorCodeAuthSignatureInvalid
 		if errors.Is(err, auth.ErrDIDNotFound) || errors.Is(err, auth.ErrInvalidDIDFormat) {
 			code = ErrorCodeAuthDIDInvalid
+		}
+		return AuthResult{
+			Error:     err,
+			ErrorCode: uint32(code),
+		}
+	}
+
+	// Check replay protection only after signature verification succeeds.
+	// Otherwise, unauthenticated traffic could burn valid sequence numbers.
+	if err := ea.replay.CheckAndMark(envAuth.SenderDID, envAuth.Sequence); err != nil {
+		code := ErrorCodeAuthReplayDetected
+		if errors.Is(err, auth.ErrTooOld) {
+			code = ErrorCodeAuthTimestampExpired // Sequence too old is similar to timestamp expired
 		}
 		return AuthResult{
 			Error:     err,

--- a/edge/gateway/internal/auth_test.go
+++ b/edge/gateway/internal/auth_test.go
@@ -314,6 +314,58 @@ func TestEnvelopeAuthenticator_InvalidSignature(t *testing.T) {
 	}
 }
 
+func TestEnvelopeAuthenticator_InvalidSignatureDoesNotConsumeReplaySequence(t *testing.T) {
+	now := time.Now()
+	clock := &mockClock{now: now}
+	config := DefaultAuthConfig()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	resolver := newMockResolver()
+	senderDID := "did:key:sender123"
+	serverDID := "did:key:server"
+	resolver.AddKey(senderDID, pub)
+
+	ea, err := NewEnvelopeAuthenticator(resolver, serverDID, config, clock)
+	if err != nil {
+		t.Fatalf("NewEnvelopeAuthenticator failed: %v", err)
+	}
+
+	timestampMs := uint64(now.UnixMilli())
+	payload := []byte("payload")
+	timestamp := time.UnixMilli(int64(timestampMs))
+	transcript := auth.BuildDIDAuthTranscript(senderDID, serverDID, payload, timestamp)
+	validSignature := ed25519.Sign(priv, transcript)
+
+	invalidAttempt := EnvelopeAuth{
+		SenderDID:    senderDID,
+		RecipientDID: serverDID,
+		TimestampMs:  timestampMs,
+		Sequence:     42,
+		Signature:    make([]byte, ed25519.SignatureSize),
+		PayloadBytes: payload,
+	}
+
+	result := ea.VerifyEnvelope(context.Background(), negotiate.ProfileSecureBaseline, invalidAttempt)
+	if result.Authenticated {
+		t.Fatal("Expected authentication to fail with invalid signature")
+	}
+	if result.ErrorCode != ErrorCodeAuthSignatureInvalid {
+		t.Fatalf("ErrorCode = %d, want %d", result.ErrorCode, ErrorCodeAuthSignatureInvalid)
+	}
+
+	validAttempt := invalidAttempt
+	validAttempt.Signature = validSignature
+
+	result = ea.VerifyEnvelope(context.Background(), negotiate.ProfileSecureBaseline, validAttempt)
+	if !result.Authenticated {
+		t.Fatalf("Valid signature with same sequence should succeed after invalid attempt, got error: %v", result.Error)
+	}
+}
+
 func TestEnvelopeAuthenticator_RecipientDIDMismatch(t *testing.T) {
 	now := time.Now()
 	clock := &mockClock{now: now}


### PR DESCRIPTION
## Summary
- Move edge gateway replay marking after Ed25519 signature verification.
- Add a regression test proving invalid signatures do not consume replay sequence numbers.
- Align the paper draft metadata with the post-PR #256 replay-order verification state.
- Update Getting Started Go requirements to match go.mod and CI Go 1.25.6.

## Root cause
The edge gateway authenticator called CheckAndMark before verifying the envelope signature. That allowed unauthenticated traffic with an invalid signature to burn a valid sequence number, causing a later legitimate envelope with that sequence to fail as replay.

## Validation
- go test ./edge/gateway/internal ./sdk/go/auth ./sdk/go/axcp
- go test ./...
- go test ./edge/gateway/internal/... ./sdk/go/...
- git diff --check

## Follow-up
After this merges, generate a new protocol proof pack from the final paper-ready commit instead of relying on the historical M7 proof pack.