### PR TITLE
[codex] Harden SDK replay validation preflight

### DIFF
--- a/docs/paper/AXCP_Core_vNext_Paper_Draft.md
+++ b/docs/paper/AXCP_Core_vNext_Paper_Draft.md
@@ -3,7 +3,7 @@
 **Working title:** AXCP Core: Message-Level Identity, Authentication, and Replay Protection for Autonomous Agent Communication
 **Draft status:** Source draft for editorial review and LaTeX conversion
 **Target venue/artifact:** Updated Zenodo preprint replacing or versioning the February 2026 AXCP v1.0 paper
-**Prepared from repository state:** `tradephantomllc/axcp-spec` `main`, after transcript-alignment PR #256 and replay-order verification updates
+**Prepared from repository state:** `tradephantomllc/axcp-spec` `main`, after transcript-alignment PR #256, replay-order verification updates, and SDK preflight hardening
 **Date:** 2026-07-05
 **Scope:** AXCP Core only, Apache 2.0 open-source repository
 
@@ -39,7 +39,7 @@ Use this as the source of truth for the final manuscript metadata:
 | Paper version | AXCP Core Paper v1.1 / 2026 revision |
 | Protocol specification | AXCP Core Specification v1.0, Secure Baseline |
 | Repository | `tradephantomllc/axcp-spec` |
-| Repository state | `main` after transcript/spec/authentication alignment and replay-order verification |
+| Repository state | `main` after transcript/spec/authentication alignment, replay-order verification, and SDK preflight hardening |
 | Publication target | Zenodo updated version under the existing concept DOI |
 | Core boundary | Apache 2.0 public repository; no Advanced/Enterprise code |
 | SDKs covered | Go, Python, TypeScript |

--- a/sdk/go/auth/validation.go
+++ b/sdk/go/auth/validation.go
@@ -115,7 +115,7 @@ type EnvelopeValidator struct {
 	// TimestampValidator validates message timestamps
 	TimestampValidator *TimestampValidator
 
-	// ReplayProtector checks for replay attacks (optional)
+	// ReplayProtector checks for replay attacks after signature verification (optional)
 	ReplayProtector *ReplayProtector
 
 	// LocalDID is this node's DID (used for recipient validation)
@@ -137,13 +137,17 @@ func (v *EnvelopeValidator) WithTimestampValidator(tv *TimestampValidator) *Enve
 	return v
 }
 
-// WithReplayProtector sets a replay protector for replay attack detection.
+// WithReplayProtector sets a replay protector for post-signature replay attack detection.
+//
+// Replay state is mutated only by validation paths that verify the envelope signature
+// first, such as ValidateAndVerifySignature. ValidateEnvelope is intentionally
+// non-mutating and does not call the replay protector.
 func (v *EnvelopeValidator) WithReplayProtector(rp *ReplayProtector) *EnvelopeValidator {
 	v.ReplayProtector = rp
 	return v
 }
 
-// ValidateEnvelope performs comprehensive validation of an incoming envelope.
+// ValidateEnvelope performs non-mutating preflight validation of an incoming envelope.
 //
 // Validation steps (in order):
 //  1. Check envelope is not nil
@@ -152,11 +156,11 @@ func (v *EnvelopeValidator) WithReplayProtector(rp *ReplayProtector) *EnvelopeVa
 //  4. Validate timestamp is within acceptable window
 //  5. Validate signature is present
 //  6. Resolve sender's public key
-//  7. Verify signature (requires transcript)
-//  8. Check replay protection (if configured)
 //
 // Note: This method does NOT verify the signature because it doesn't have
-// access to the full transcript. Use ValidateAndVerify for complete validation.
+// access to the full transcript. It also does NOT mutate replay state. Use
+// ValidateAndVerifySignature for complete validation with post-signature replay
+// protection.
 func (v *EnvelopeValidator) ValidateEnvelope(ctx context.Context, env EnvelopeFields) error {
 	// 1. Check envelope not nil
 	if env == nil {
@@ -191,23 +195,15 @@ func (v *EnvelopeValidator) ValidateEnvelope(ctx context.Context, env EnvelopeFi
 		return err
 	}
 
-	// 7. Replay protection (if configured)
-	if v.ReplayProtector != nil {
-		peerID := env.GetSenderDid()
-		seq := env.GetSequence()
-		if err := v.ReplayProtector.CheckAndMark(peerID, seq); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
 // ValidateAndVerifySignature validates the envelope and verifies the signature.
 //
 // This is the complete validation flow:
-//  1. All basic validations from ValidateEnvelope
+//  1. All non-mutating preflight validations from ValidateEnvelope
 //  2. Verify Ed25519 signature over the provided transcript
+//  3. Check replay protection, mutating replay state only after successful signature verification
 //
 // The transcript should be built using BuildDIDAuthTranscript or similar
 // to ensure proper binding of the signature to the message context.

--- a/sdk/go/auth/validation_test.go
+++ b/sdk/go/auth/validation_test.go
@@ -16,11 +16,11 @@ type mockEnvelope struct {
 	signature    []byte
 }
 
-func (m *mockEnvelope) GetSenderDid() string     { return m.senderDID }
-func (m *mockEnvelope) GetRecipientDid() string  { return m.recipientDID }
-func (m *mockEnvelope) GetTimestampMs() uint64   { return m.timestampMs }
-func (m *mockEnvelope) GetSequence() uint64      { return m.sequence }
-func (m *mockEnvelope) GetSignature() []byte     { return m.signature }
+func (m *mockEnvelope) GetSenderDid() string    { return m.senderDID }
+func (m *mockEnvelope) GetRecipientDid() string { return m.recipientDID }
+func (m *mockEnvelope) GetTimestampMs() uint64  { return m.timestampMs }
+func (m *mockEnvelope) GetSequence() uint64     { return m.sequence }
+func (m *mockEnvelope) GetSignature() []byte    { return m.signature }
 
 func TestValidateRecipient_Valid(t *testing.T) {
 	env := &mockEnvelope{
@@ -316,7 +316,7 @@ func TestEnvelopeValidator_ValidateEnvelope_Errors(t *testing.T) {
 	}
 }
 
-func TestEnvelopeValidator_WithReplayProtector(t *testing.T) {
+func TestEnvelopeValidator_ValidateEnvelopeDoesNotMutateReplayProtector(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
 	resolver := NewMemoryDIDResolver()
@@ -338,23 +338,95 @@ func TestEnvelopeValidator_WithReplayProtector(t *testing.T) {
 		signature:    make([]byte, 64),
 	}
 
-	// First call should succeed
+	// ValidateEnvelope is preflight-only and should not mark replay state.
 	err = v.ValidateEnvelope(context.Background(), env)
 	if err != nil {
 		t.Errorf("first call should succeed: %v", err)
 	}
 
-	// Second call with same sequence should fail (replay)
-	err = v.ValidateEnvelope(context.Background(), env)
-	if err == nil {
-		t.Error("second call should fail due to replay detection")
-	}
-
-	// New sequence should succeed
-	env.sequence = 2
 	err = v.ValidateEnvelope(context.Background(), env)
 	if err != nil {
+		t.Errorf("second preflight call with same sequence should not fail as replay: %v", err)
+	}
+}
+
+func TestEnvelopeValidator_WithReplayProtector(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	resolver := NewMemoryDIDResolver()
+	resolver.AddDID("did:key:sender", pub)
+
+	rp, err := NewReplayProtector(5*time.Minute, 100, nil)
+	if err != nil {
+		t.Fatalf("failed to create replay protector: %v", err)
+	}
+
+	v := NewEnvelopeValidator(resolver, "did:key:recipient").
+		WithReplayProtector(rp)
+
+	transcript := []byte("test-transcript-data")
+	signature := ed25519.Sign(priv, transcript)
+	env := &mockEnvelope{
+		senderDID:    "did:key:sender",
+		recipientDID: "did:key:recipient",
+		timestampMs:  NowMs(),
+		sequence:     1,
+		signature:    signature,
+	}
+
+	// First verified call should succeed and mark replay state.
+	err = v.ValidateAndVerifySignature(context.Background(), env, transcript)
+	if err != nil {
+		t.Errorf("first call should succeed: %v", err)
+	}
+
+	// Second verified call with same sequence should fail.
+	err = v.ValidateAndVerifySignature(context.Background(), env, transcript)
+	if err == nil {
+		t.Fatal("second call should fail due to replay detection")
+	}
+
+	// New sequence should succeed.
+	env.sequence = 2
+	err = v.ValidateAndVerifySignature(context.Background(), env, transcript)
+	if err != nil {
 		t.Errorf("new sequence should succeed: %v", err)
+	}
+}
+
+func TestEnvelopeValidator_InvalidSignatureDoesNotConsumeReplaySequence(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	resolver := NewMemoryDIDResolver()
+	resolver.AddDID("did:key:sender", pub)
+
+	rp, err := NewReplayProtector(5*time.Minute, 100, nil)
+	if err != nil {
+		t.Fatalf("failed to create replay protector: %v", err)
+	}
+
+	v := NewEnvelopeValidator(resolver, "did:key:recipient").
+		WithReplayProtector(rp)
+
+	transcript := []byte("test-transcript-data")
+	validSignature := ed25519.Sign(priv, transcript)
+	env := &mockEnvelope{
+		senderDID:    "did:key:sender",
+		recipientDID: "did:key:recipient",
+		timestampMs:  NowMs(),
+		sequence:     42,
+		signature:    make([]byte, ed25519.SignatureSize),
+	}
+
+	err = v.ValidateAndVerifySignature(context.Background(), env, transcript)
+	if err != ErrVerificationFailed {
+		t.Fatalf("invalid signature error = %v, want %v", err, ErrVerificationFailed)
+	}
+
+	env.signature = validSignature
+	err = v.ValidateAndVerifySignature(context.Background(), env, transcript)
+	if err != nil {
+		t.Fatalf("valid signature with same sequence should succeed after invalid attempt: %v", err)
 	}
 }
 

--- a/sdk/go/axcp/validator.go
+++ b/sdk/go/axcp/validator.go
@@ -18,7 +18,7 @@ type ValidatorConfig struct {
 	// TimestampValidator validates message timestamps (nil uses default)
 	TimestampValidator *auth.TimestampValidator
 
-	// ReplayProtector checks for replay attacks (nil disables replay protection)
+	// ReplayProtector checks for replay attacks after signature verification (nil disables replay protection)
 	ReplayProtector *auth.ReplayProtector
 
 	// SkipSignatureVerification skips signature verification (for testing only)
@@ -50,7 +50,9 @@ func NewValidator(config ValidatorConfig) *Validator {
 	}
 }
 
-// ValidateEnvelope validates an envelope without signature verification.
+// ValidateEnvelope performs non-mutating preflight validation without signature verification.
+// Replay protection is intentionally not applied here because replay state must only
+// be mutated after successful signature verification.
 // Returns a ProtocolError if validation fails.
 func (v *Validator) ValidateEnvelope(ctx context.Context, env *Envelope) *ProtocolError {
 	if env == nil {

--- a/sdk/go/axcp/validator_test.go
+++ b/sdk/go/axcp/validator_test.go
@@ -298,6 +298,47 @@ func TestValidator_WithReplayProtection(t *testing.T) {
 	}
 }
 
+func TestValidator_ValidateEnvelopeDoesNotConsumeReplaySequence(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	senderDID := "did:key:sender"
+	localDID := "did:key:local"
+
+	resolver := auth.NewMemoryDIDResolver()
+	resolver.AddDID(senderDID, pub)
+
+	rp, _ := auth.NewReplayProtector(5*time.Minute, 100, nil)
+
+	v := NewValidator(ValidatorConfig{
+		LocalDID:        localDID,
+		Resolver:        resolver,
+		ReplayProtector: rp,
+	})
+
+	env := NewEnvelope("trace-123", 1)
+	env.SenderDid = senderDID
+	env.RecipientDid = localDID
+	env.TimestampMs = auth.NowMs()
+	env.Sequence = 42
+	env.Signature = make([]byte, ed25519.SignatureSize)
+
+	// Preflight validation does not verify the signature and must not mark replay state.
+	perr := v.ValidateEnvelope(context.Background(), env)
+	if perr != nil {
+		t.Fatalf("ValidateEnvelope() unexpected error: %v", perr)
+	}
+
+	perr = v.ValidateEnvelope(context.Background(), env)
+	if perr != nil {
+		t.Fatalf("ValidateEnvelope() should remain non-mutating for replay state: %v", perr)
+	}
+
+	env.Signature = ed25519.Sign(priv, buildEnvelopeTranscript(env))
+	perr = v.ValidateAndVerify(context.Background(), env)
+	if perr != nil {
+		t.Fatalf("ValidateAndVerify() should accept same sequence after preflight-only validation: %v", perr)
+	}
+}
+
 func TestValidatorMiddleware(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	senderDID := "did:key:sender"


### PR DESCRIPTION
## Summary
- Make `sdk/go/auth.ValidateEnvelope` explicitly non-mutating preflight validation.
- Keep replay state mutation only in post-signature validation paths.
- Add SDK regressions covering preflight non-mutation and invalid-signature sequence preservation.
- Clarify the `sdk/go/axcp.Validator.ValidateEnvelope` wrapper contract.
- Update the paper draft metadata to include SDK preflight hardening before the final proof pack.

## Root cause
The gateway edge path was fixed in PR #257, but the public Go SDK still exposed a footgun: `ValidateEnvelope` could mark replay state when configured with a `ReplayProtector`, even though it does not verify signatures because it has no transcript. That made the public API appear to violate the paper/spec rule that replay state must only be mutated after signature verification.

## Validation
- go test ./sdk/go/auth ./sdk/go/axcp
- go test ./edge/gateway/internal/... ./sdk/go/...
- go test ./...
- go vet ./sdk/go/auth ./sdk/go/axcp
- git diff --check

## Follow-up
After this merges, generate Proof Pack M8 from the final commit and use that commit/hash for the Zenodo-ready paper package.